### PR TITLE
Add code highlighting to all homepage tabs

### DIFF
--- a/docs/app/components/code-example.tsx
+++ b/docs/app/components/code-example.tsx
@@ -158,6 +158,16 @@ const tabLabels: Record<TabKey, string> = {
   cli: "CLI",
 }
 
+const tabLanguages: Record<TabKey, string> = {
+  basic: "javascript",
+  reactive: "javascript",
+  typescript: "typescript",
+  config: "javascript",
+  mock: "javascript",
+  features: "javascript",
+  cli: "bash",
+}
+
 export function CodeExample() {
   const [activeTab, setActiveTab] = useState<TabKey>("basic")
   const [copied, setCopied] = useState(false)
@@ -211,7 +221,7 @@ export function CodeExample() {
               </Button>
             </div>
             <pre className="p-6 overflow-x-auto text-sm max-h-[400px] overflow-y-auto">
-              <code ref={codeRef} className={`font-mono language-${activeTab === 'cli' ? 'bash' : 'javascript'}`}>{codeExamples[activeTab]}</code>
+              <code ref={codeRef} className={`font-mono language-${tabLanguages[activeTab]}`}>{codeExamples[activeTab]}</code>
             </pre>
           </div>
         </div>


### PR DESCRIPTION
Added language mapping for each tab to ensure correct syntax highlighting:
- TypeScript tab now uses 'typescript' highlighting instead of 'javascript'
- All tabs (Basic, Reactive, Config, Mock, Features, CLI) now have proper language-specific highlighting
- Replaced conditional logic with a cleaner tabLanguages mapping object