### PR TITLE
Add highlight.js support to all homepage tabs

### DIFF
--- a/docs/app/components/code-example.tsx
+++ b/docs/app/components/code-example.tsx
@@ -181,6 +181,8 @@ export function CodeExample() {
 
   useEffect(() => {
     if (codeRef.current) {
+      // Remove previous highlighting before applying new highlighting
+      delete codeRef.current.dataset.highlighted
       hljs.highlightElement(codeRef.current)
     }
   }, [activeTab])


### PR DESCRIPTION
- Clear previous highlighting before applying new highlighting when switching tabs
- Ensures all tabs (Basic, Reactive, TypeScript, Config, Mock, Features, CLI) get proper syntax highlighting
- Fixes issue where only the first tab was being highlighted correctly