### PR TITLE
Fix icon loading in Fumadocs

### DIFF
--- a/docs/components/icon.tsx
+++ b/docs/components/icon.tsx
@@ -1,0 +1,16 @@
+import type { LucideIcon } from 'lucide-react';
+import { TerminalIcon } from 'lucide-react';
+
+export default function IconContainer({
+  icon: Icon,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { icon?: LucideIcon }) {
+  return (
+    <div
+      {...props}
+      className="rounded-md border bg-gradient-to-b from-muted to-secondary p-0.5 shadow-md"
+    >
+      {Icon ? <Icon /> : <TerminalIcon />}
+    </div>
+  );
+}

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -2,12 +2,34 @@ import { loader } from 'fumadocs-core/source';
 import { createOpenAPI } from 'fumadocs-openapi/server';
 import { docs } from 'fumadocs-mdx:collections/server';
 import { openapiPlugin } from 'fumadocs-openapi/server';
+import { icons } from 'lucide-react';
+import { createElement } from 'react';
+import IconContainer from '@/components/icon';
 
 export const source = loader({
   baseUrl: '/docs',
   plugins: [openapiPlugin()],
 
   source: docs.toFumadocsSource(),
+
+  icon(iconName) {
+    if (!iconName) return;
+
+    // Convert kebab-case to PascalCase (e.g., help-circle -> HelpCircle)
+    const pascalIconName = iconName
+      .split('-')
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join('');
+
+    // Try both the original name and the converted PascalCase name
+    const iconKey = (iconName in icons ? iconName : pascalIconName) as keyof typeof icons;
+
+    if (iconKey in icons) {
+      return createElement(IconContainer, {
+        icon: icons[iconKey],
+      });
+    }
+  },
 });
 
 export const openapi = createOpenAPI({


### PR DESCRIPTION
Add icon handler to convert icon names from MDX frontmatter to Lucide React components:

- Create IconContainer component with styled wrapper for icons
- Implement icon() handler in source loader to map icon names to components
- Support both PascalCase and kebab-case icon name formats (e.g., BookOpen and help-circle)
- Icons now render properly in docs sidebar with consistent theming

Resolves issue where icons were defined in frontmatter but not displayed.