### PR TITLE
fix: use middleware to intercept .mdx requests before Turbopack modul…

### DIFF
--- a/docs/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -8,7 +8,8 @@ export async function GET(
   { params }: RouteContext<"/llms.mdx/docs/[[...slug]]">,
 ) {
   const { slug } = await params;
-  const page = source.getPage(slug);
+  const cleanSlug = slug?.map((s, i) => i === slug.length - 1 ? s.replace(/\.mdx$/, '') : s);
+  const page = source.getPage(cleanSlug);
   if (!page) notFound();
 
   return new Response(await getLLMText(page), {

--- a/docs/middleware.ts
+++ b/docs/middleware.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname.startsWith('/docs/') && pathname.endsWith('.mdx')) {
+    const slug = pathname.slice('/docs/'.length, -'.mdx'.length);
+    const url = request.nextUrl.clone();
+    url.pathname = `/llms.mdx/docs/${slug}`;
+    return NextResponse.rewrite(url);
+  }
+}
+
+export const config = {
+  matcher: '/docs/:path+',
+};

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -18,14 +18,6 @@ export const config = {
   turbopack: {
     root: resolve(import.meta.dirname, '..'),
   },
-  async rewrites() {
-    return [
-      {
-        source: '/docs/:path*.mdx',  
-        destination: '/llms.mdx/docs/:path*',
-      },
-    ];
-  },
   reactStrictMode: false,
   images: {
     remotePatterns: [


### PR DESCRIPTION
…e resolution

Rewrites in next.config.ts run after Turbopack/webpack processes .mdx files as JS modules, causing binary responses. Middleware runs earlier (edge layer) and reliably rewrites /docs/*.mdx → /llms.mdx/docs/* before routing.

Also removes the now-redundant next.config.ts rewrite and adds defensive .mdx extension stripping in the route handler.

https://claude.ai/code/session_013vDeDE6XDXgSMeC7YThLRq