### PR TITLE
Add CLI dependencies and fix route type annotation

### DIFF
--- a/docs/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/docs/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -5,7 +5,7 @@ export const revalidate = false;
 
 export async function GET(
   _req: Request,
-  { params }: RouteContext<"/docs/llms.mdx/docs/[[...slug]]">,
+  { params }: { params: Promise<{ slug?: string[] }> },
 ) {
   const { slug } = await params;
   const cleanSlug = slug?.map((s, i) => i === slug.length - 1 ? s.replace(/\.mdx$/, '') : s);

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
     "test": "vitest",
     "test:cli": "bun src/grab-url-cli/index.ts https://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-live-server-amd64.iso"
   },
+  "dependencies": {
+    "chalk": "^5.3.0",
+    "cli-table3": "^0.6.3",
+    "cli-progress": "^3.12.0"
+  },
   "devDependencies": {
     "@grab-url/loading-animations": "workspace:*",
     "@vitest/ui": "^4.0.18",


### PR DESCRIPTION
## Summary
This PR adds CLI tool dependencies and fixes a TypeScript type annotation in the docs route handler.

## Key Changes
- **Dependencies**: Added three new packages to support CLI functionality:
  - `chalk` (^5.3.0) - for terminal string styling
  - `cli-table3` (^0.6.3) - for formatted table output
  - `cli-progress` (^3.12.0) - for progress bar display

- **Type Fix**: Updated the route handler parameter type in `docs/app/llms.mdx/docs/[[...slug]]/route.ts` from a generic `RouteContext` to an explicit inline type annotation `{ params: Promise<{ slug?: string[] }> }` for better type safety and clarity

## Implementation Details
The CLI dependencies suggest upcoming enhancements to the grab-url CLI tool to provide better user feedback through styled output, tabular data display, and progress indicators. The route type annotation change improves type specificity and aligns with Next.js App Router patterns.

https://claude.ai/code/session_01THZYWMzM3mm6RTRpFRyr6i