### PR TITLE
Add mobile info button to badge tooltip component

### DIFF
--- a/docs/components/fumadocs/code-tree/badge-tooltip.module.css
+++ b/docs/components/fumadocs/code-tree/badge-tooltip.module.css
@@ -15,6 +15,27 @@
   line-height: 1;
 }
 
+.mobileInfoButton {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  line-height: 1;
+  opacity: 0.65;
+  flex-shrink: 0;
+}
+
+@media (hover: none) {
+  .mobileInfoButton {
+    display: inline-flex;
+  }
+}
+
 .tooltip {
   padding: 0.6rem 0.85rem;
   border-radius: 0.5rem;

--- a/docs/components/fumadocs/code-tree/badge-tooltip.tsx
+++ b/docs/components/fumadocs/code-tree/badge-tooltip.tsx
@@ -4,7 +4,7 @@
  * Reusable badge component with an interactive tooltip for displaying rich metadata.
  */
 import { useRef, useState, useCallback, useEffect } from "react";
-import { Package, FunctionSquare, Braces, FileOutput, FileInput, Box, Blocks } from "lucide-react";
+import { Package, FunctionSquare, Braces, FileOutput, FileInput, Box, Blocks, Info } from "lucide-react";
 import type { TypeProperty } from "@/lib/fumadocs/code-graph";
 import styles from "./badge-tooltip.module.css";
 import { Markdown } from "../typography/markdown";
@@ -201,6 +201,14 @@ export function Badge({
         <Icon size={12} />
       </button>
       <span onClick={href ? openSource : undefined}>{label}</span>
+      <button
+        type="button"
+        onClick={togglePin}
+        aria-label={`${pinned ? "Hide" : "Show"} info for ${label}`}
+        className={styles.mobileInfoButton}
+      >
+        <Info size={11} />
+      </button>
       {pos && (
         <div
           ref={tooltipRef}


### PR DESCRIPTION
## Summary
Added a mobile-friendly info button to the badge tooltip component that appears on devices without hover capability, allowing users to toggle tooltip visibility on touch devices.

## Key Changes
- **New mobile info button styling**: Added `.mobileInfoButton` CSS class that is hidden by default and only displayed on devices without hover support (`@media (hover: none)`)
- **Button implementation**: Added an interactive info button with the Info icon from lucide-react that triggers the existing `togglePin` function
- **Icon import**: Added `Info` icon to the lucide-react imports to support the new button
- **Accessibility**: Included proper `aria-label` that dynamically reflects the pinned state and badge label

## Implementation Details
- The button uses the existing `togglePin` callback, maintaining consistency with the current tooltip interaction pattern
- The mobile button is positioned inline with the badge label and icon
- Styling includes appropriate opacity (0.65) and cursor feedback to indicate interactivity
- The button only appears on touch devices (via `@media (hover: none)`) to avoid cluttering the desktop UI

https://claude.ai/code/session_01CXvctLtYhm1VarTxUzUjZC