### PR TITLE
Clean up layout navigation and fix homepage overflow

### DIFF
--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -17,7 +17,7 @@ const inter = Inter({
 
 export default function Home() {
   return (
-    <main className={`${inter.className} min-h-screen bg-background`}>
+    <main className={`${inter.className} min-h-screen bg-background overflow-x-hidden`}>
       <HeroSection />
       <FeaturesGrid />
       <CodeExample />

--- a/docs/app/layout.config.tsx
+++ b/docs/app/layout.config.tsx
@@ -3,7 +3,7 @@
  * @description Configuration for the documentation layout, including navigation and links.
  */
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
-import { BookOpen, Link2 } from 'lucide-react';
+import { Link2 } from 'lucide-react';
 import { docsConfig } from '@/lib/fumadocs/customize-docs';
 
 export const baseOptions: BaseLayoutProps = {
@@ -15,13 +15,6 @@ export const baseOptions: BaseLayoutProps = {
       </span>
     ),
   },
-  links: [
-    {
-      label: 'Docs',
-      icon: <BookOpen />,
-      text: 'Docs',
-      url: '/docs',
-    },
-  ],
+  links: [],
   githubUrl: 'https://github.com/vtempest/grab-url',
 };


### PR DESCRIPTION
## Summary
This PR removes unused navigation links from the documentation layout configuration and fixes a horizontal overflow issue on the homepage.

## Key Changes
- **Removed unused navigation links**: Deleted the `links` array entry containing a "Docs" link with BookOpen icon from the layout configuration, as it appears to be redundant or no longer needed
- **Removed unused import**: Cleaned up the `BookOpen` icon import from lucide-react since it's no longer used
- **Fixed homepage overflow**: Added `overflow-x-hidden` class to the main homepage container to prevent horizontal scrolling

## Implementation Details
- The `links` array in `baseOptions` is now empty, simplifying the layout navigation
- The homepage now properly constrains content width and prevents unwanted horizontal overflow, improving the user experience on smaller viewports

https://claude.ai/code/session_019HQ4SawmbCDAWJDDimPZ5N