### PR TITLE
docs: align badge rows with debate-ai.com badge parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,21 @@
   <a href="https://grab.js.org/docs/examples">🎯 Examples</a>
 </h3>
 <p align="center">
-  <a href="https://deepwiki.com/vtempest/GRAB-URL"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
-  <a href="https://discord.gg/SJdBqBz3tV"><img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat"
-          alt="Join Discord" /></a>
-  <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/vtempest/GRAB-URL" /></a>
-  <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Discussions"
-      src="https://img.shields.io/github/discussions/vtempest/GRAB-URL" /></a>
-  <br />
-  <a href="https://github.com/vtempest/GRAB-URL/pulse"><img src="https://img.shields.io/github/commit-activity/m/vtempest/GRAB-URL" alt="Activity" /></a>
-  <a href="https://github.com/vtempest/GRAB-URL/commits/master/"><img src="https://img.shields.io/github/last-commit/vtempest/GRAB-URL.svg" alt="GitHub last commit" /></a>
-  <br />
-  <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI">
-  <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
+    <a href="https://deepwiki.com/vtempest/GRAB-URL"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+    <a href="https://grab.js.org"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/vtempest/GRAB-URL" /></a>
+<br />
+    <a href="https://github.com/vtempest/GRAB-URL/pulse"><img src="https://img.shields.io/github/commit-activity/m/vtempest/GRAB-URL" alt="Activity" /></a>
+    <a href="https://github.com/vtempest/GRAB-URL/commits/master/"><img src="https://img.shields.io/github/last-commit/vtempest/GRAB-URL.svg" alt="GitHub last commit" /></a>
+    <a href="https://github.com/OpenSourceAGI/GRAB-URL/actions/workflows/tests.yml"><img src="https://github.com/OpenSourceAGI/GRAB-URL/actions/workflows/tests.yml/badge.svg" alt="Test grab-url status for master" /></a>
+    <br />
+    <a href="https://app.codecov.io/gh/OpenSourceAGI/GRAB-URL"><img src="https://codecov.io/gh/OpenSourceAGI/GRAB-URL/branch/master/graph/badge.svg" alt="Coverage" /></a>
+    <a href="https://discord.gg/SJdBqBz3tV"><img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
+    <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
+<img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI">
+   <br />
+  <a href="https://npmjs.org/package/grab-url"><img alt="NPM Version" src="https://img.shields.io/npm/v/grab-url" /></a>
+  <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/vtempest/GRAB-URL" /></a>
   <a href="https://codespaces.new/vtempest/GRAB-URL"><img src="https://github.com/codespaces/badge.svg" width="150" height="20" alt="GitHub Codespaces" /></a>
 </p>
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -11,20 +11,22 @@ displayed_sidebar: lib
     <img width="400px" src="https://i.imgur.com/RH80JGZ.png" />
 </p>
 <p align="center" >
-  <a href="https://discord.gg/SJdBqBz3tV">
-      <img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat"
-            alt="Join Discord" />
-    </a>     <a href="https://github.com/vtempest/GRAB-URL/discussions">
-     <img alt="GitHub Stars" src="https://img.shields.io/github/stars/vtempest/GRAB-URL" /></a> <a href="https://npmjs.org/package/grab-url">
-    <img alt="NPM Version" src="https://img.shields.io/npm/v/grab-url" />
-  </a>    <a href="https://github.com/vtempest/GRAB-URL/discussions">
-    <img alt="GitHub Discussions"
-        src="https://img.shields.io/github/discussions/vtempest/GRAB-URL" />
-    </a> <a href="https://github.blog/developer-skills/github/beginners-guide-to-github-creating-a-pull-request/">
-        <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"/>
-    </a> <a href="https://codespaces.new/vtempest/GRAB-URL">
-    <img src="https://github.com/codespaces/badge.svg" width="150" height="20"/>
-    </a>
+    <a href="https://deepwiki.com/vtempest/GRAB-URL"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+    <a href="https://grab.js.org"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
+    <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/vtempest/GRAB-URL" /></a>
+    <br />
+    <a href="https://github.com/vtempest/GRAB-URL/pulse"><img src="https://img.shields.io/github/commit-activity/m/vtempest/GRAB-URL" alt="Activity" /></a>
+    <a href="https://github.com/vtempest/GRAB-URL/commits/master/"><img src="https://img.shields.io/github/last-commit/vtempest/GRAB-URL.svg" alt="GitHub last commit" /></a>
+    <a href="https://github.com/OpenSourceAGI/GRAB-URL/actions/workflows/tests.yml"><img src="https://github.com/OpenSourceAGI/GRAB-URL/actions/workflows/tests.yml/badge.svg" alt="Test grab-url status for master" /></a>
+    <br />
+    <a href="https://app.codecov.io/gh/OpenSourceAGI/GRAB-URL"><img src="https://codecov.io/gh/OpenSourceAGI/GRAB-URL/branch/master/graph/badge.svg" alt="Coverage" /></a>
+    <a href="https://discord.gg/SJdBqBz3tV"><img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
+    <a href="https://github.blog/developer-skills/github/beginners-guide-to-github-creating-a-pull-request/"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"/></a>
+    <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI">
+    <br />
+    <a href="https://npmjs.org/package/grab-url"><img alt="NPM Version" src="https://img.shields.io/npm/v/grab-url" /></a>
+    <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/vtempest/GRAB-URL" /></a>
+    <a href="https://codespaces.new/vtempest/GRAB-URL"><img src="https://github.com/codespaces/badge.svg" width="150" height="20"/></a>
 </p>
 <h3 align="center">
   <a href="https://grab.js.org"> 📑 Docs (grab.js.org)</a>


### PR DESCRIPTION
## Summary
- Reordered and expanded the badge row in `README.md` and `docs/content/docs/index.mdx` to mirror the structure/order of the [debate/debate-ai.com](https://github.com/debate/debate-ai.com) README badges, using only the badges applicable to GRAB-URL, pointed at GRAB-URL's own URLs.
- Added a **Docs** badge (readthedocs-style, linking to `grab.js.org`), a **Tests** GitHub Actions workflow badge (`.github/workflows/tests.yml`), and a **Codecov** coverage badge (`https://app.codecov.io/gh/OpenSourceAGI/GRAB-URL`) to both files — these existed in debate-ai.com's badge set but were missing from GRAB-URL's.
- Skipped debate-ai.com badges that don't apply to GRAB-URL (API docs badge, YouTube, Cloudflare Workers deploy button, Uptime status, Zenodo DOIs, and the big app/community call-to-action badges), since GRAB-URL is a library, not a hosted app.
- Kept GRAB-URL-specific badges (NPM version, GitHub Discussions, Codespaces) that don't have a debate-ai.com counterpart, grouped at the end of the badge block.

## Test plan
- [x] Verified new badge URLs (Actions workflow, Codecov) match the actual workflow file name (`.github/workflows/tests.yml`) and the Codecov slug already configured in that workflow (`OpenSourceAGI/grab-url`).
- [ ] Visually confirm badges render correctly on GitHub once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFXxrQYFmLFk4JjpgQgtHc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFXxrQYFmLFk4JjpgQgtHc)_