### PR TITLE
docs: add npm downloads and bundle size badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@
     <a href="https://app.codecov.io/gh/OpenSourceAGI/GRAB-URL"><img src="https://codecov.io/gh/OpenSourceAGI/GRAB-URL/branch/master/graph/badge.svg" alt="Coverage" /></a>
     <a href="https://discord.gg/SJdBqBz3tV"><img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
     <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
-<img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI">
+<img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI"> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" alt="TypeScript" />
    <br />
   <a href="https://npmjs.org/package/grab-url"><img alt="NPM Version" src="https://img.shields.io/npm/v/grab-url" /></a>
+  <a href="https://npmjs.org/package/grab-url"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/grab-url" /></a>
+  <a href="https://bundlephobia.com/package/grab-url"><img alt="Bundle Size" src="https://img.shields.io/bundlephobia/minzip/grab-url" /></a>
   <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/vtempest/GRAB-URL" /></a>
   <a href="https://codespaces.new/vtempest/GRAB-URL"><img src="https://github.com/codespaces/badge.svg" width="150" height="20" alt="GitHub Codespaces" /></a>
 </p>


### PR DESCRIPTION
## Summary
- Add an NPM Downloads badge next to the existing NPM Version badge
- Add a Bundle Size (bundlephobia) badge, reinforcing the "4KB" size claim already in the comparison table
- Add a TypeScript tech badge next to the Claude AI badge

These mirror the badge style/coverage used in the [debate-ai.com](https://github.com/debate/debate-ai.com) README (stats, tech badges, package badges), adapted to what's relevant for an npm library.

## Test plan
- [x] Verified badge URLs follow the standard shields.io/bundlephobia conventions used elsewhere in this README
- [ ] Visually confirm badges render correctly on GitHub once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zE9Cdw2C3bFRY3yQddik4

---
_Generated by [Claude Code](https://claude.ai/code/session_013zE9Cdw2C3bFRY3yQddik4)_