### PR TITLE
Add grab.js.org website badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
   <a href="https://bundlephobia.com/package/grab-url"><img alt="Bundle Size" src="https://img.shields.io/bundlephobia/minzip/grab-url" /></a>
   <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/vtempest/GRAB-URL" /></a>
   <a href="https://codespaces.new/vtempest/GRAB-URL"><img src="https://github.com/codespaces/badge.svg" width="150" height="20" alt="GitHub Codespaces" /></a>
+  <a href="https://grab.js.org"><img src="https://i.imgur.com/EWze7Ew.png" height="20" alt="grab.js.org" /></a>
 </p>
 
 ```bash


### PR DESCRIPTION
## Summary
Added a badge linking to the official grab.js.org website in the README's badge section.

## Changes
- Added a new badge link to https://grab.js.org with a custom logo image from imgur
- Badge is positioned alongside other project badges (Bundle Size, GitHub Discussions, GitHub Codespaces)

## Details
This badge helps direct users to the project's official documentation website and improves project visibility by showcasing the dedicated web presence.

https://claude.ai/code/session_016zSUaaEFUipzSBDsmoZ9e4