### PR TITLE
Update README badge image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
         <img  src="https://i.imgur.com/xzFQmrD.jpeg" />
 <br />
-        <a href="https://grab.js.org"><img src="https://i.imgur.com/EWze7Ew.png" height="20" alt="grab.js.org" /></a>
+        <a href="https://grab.js.org"><img src="https://i.imgur.com/m7UyxgV.png" height="20" alt="grab.js.org" /></a>
     <a href="https://deepwiki.com/vtempest/GRAB-URL"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
     <a href="https://grab.js.org"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
     <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/vtempest/GRAB-URL" /></a>


### PR DESCRIPTION
## Summary
Updated the grab.js.org badge image URL in the README to point to a new image asset.

## Changes
- Updated the badge image source URL from `https://i.imgur.com/EWze7Ew.png` to `https://i.imgur.com/m7UyxgV.png`
- The badge maintains the same height (20px) and alt text ("grab.js.org")
- The link destination remains unchanged

## Details
This appears to be a maintenance update to refresh the badge image asset, possibly due to the previous image being unavailable or needing to be replaced with an updated version.

https://claude.ai/code/session_01QrkAr4zAUHrjmdKa7yxaNM