### PR TITLE
fix(docs): add missing @opennextjs/cloudflare dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@fumadocs/mdx-remote": "^1.4.3",
+    "@opennextjs/cloudflare": "latest",
     "@orama/orama": "^3.1.16",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## Summary
- `docs/next.config.ts` imports `initOpenNextCloudflareForDev` from `@opennextjs/cloudflare` unconditionally, and `docs/open-next.config.ts` imports `defineCloudflareConfig` from the same package, but it was never added to `docs/package.json`.
- Every production deploy on Vercel for the `grab-url` project has been failing with `Error: Cannot find module '@opennextjs/cloudflare'` during `bun run build` — confirmed across deployments going back through at least PR #15, so this predates the StackBlitz/template-fumadocs work merged in PR #20 and isn't caused by it.
- Adds `"@opennextjs/cloudflare": "latest"` to `docs/package.json` dependencies (matching the existing `"vinext": "latest"` convention in the same file) so the module resolves during the build.

## Test plan
- [ ] Vercel picks this branch up and the docs build (`bun run build` inside `docs/`) completes without the missing-module error.
- [ ] `next dev` / `next build` still work locally (no other Cloudflare wiring changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9rDMedtHHm8MCRRRmbVUo

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9rDMedtHHm8MCRRRmbVUo)_