### PR TITLE
feat(heyapi-client-grab): add SSE support to the grab-powered Hey API client

### DIFF
--- a/packages/heyapi-client-grab/README.md
+++ b/packages/heyapi-client-grab/README.md
@@ -121,13 +121,38 @@ if (error) console.log(response.status, error); // 404 { message: "Pet not found
 
 `buildUrl()`, `interceptors.request/response/error`, `security`/`auth`, `bodySerializer`, `querySerializer`, `parseAs`, `responseValidator` and `responseTransformer` all behave as they do in the official clients.
 
+## Server-sent events
+
+An operation whose response is `text/event-stream` generates an SDK function that calls `client.sse.<method>()` instead of `client.<method>()`, and returns `{ stream }` — an async generator of parsed event data:
+
+```ts
+import { streamJobEvents } from "./client";
+
+const { stream } = await streamJobEvents({ path: { jobId: "42" } });
+
+for await (const event of stream) console.log(event); // parsed `data:` payload
+```
+
+SSE is a long-lived connection, not a single request/response, so it connects with `fetch` directly instead of going through grab — grab's cache/retry/rate-limit model is built around a request that completes, not one that stays open and reconnects on its own. Pass these alongside the usual request options:
+
+| Option                    | Effect                                                             |
+| ------------------------- | ------------------------------------------------------------------- |
+| `onSseEvent`               | Called for every event, with its `data`, `event`, `id` and `retry`  |
+| `onSseError`               | Called when a connection attempt fails, before it retries           |
+| `sseDefaultRetryDelay`     | default=3000 Delay before the first retry, in ms                    |
+| `sseMaxRetryAttempts`      | Give up after this many retry attempts                              |
+| `sseMaxRetryDelay`         | default=30000 Cap on the exponential backoff delay, in ms           |
+| `fetch`                    | Fetch implementation to use — default=`globalThis.fetch`            |
+
+Reconnects honor the server's `retry:` field and send `Last-Event-ID` from the last event's `id:`, matching browser `EventSource` semantics. A stream that ends normally (the server closes the connection) does not reconnect — only a network or parse error does.
+
 ## Differences from `@hey-api/client-fetch`
 
 - **Transport failures are returned, not thrown.** A timeout or connection failure comes back as `{ error }` (or throws when `throwOnError` is set), matching grab's "errors are data" behavior. HTTP error statuses behave the same as in the official clients.
 - **Bodies are parsed by grab.** `parseAs: "stream"` hands you the raw stream, and an explicit `parseAs` still decides the empty-response shape, but otherwise grab's content-type detection reads the body.
 - **grab sets JSON `Content-Type`/`Accept` defaults** on requests that do not specify their own, including body-less ones.
 - **Response interceptors run before parsing**, on a response whose body grab has already read.
-- **No `sse` helpers.** Server-sent event endpoints need the fetch client.
+- **`sse` endpoints bypass grab** and connect with `fetch` directly — see [Server-sent events](#server-sent-events).
 
 ## Requirements
 
@@ -140,8 +165,8 @@ Works with any `grab-url` ≥ 1.6.22. On 1.6.23 and later it also uses the `onRa
 | [src/client.ts](src/client.ts)                           | `createClient()` — the Hey API interface over grab    |
 | [src/types.ts](src/types.ts)                             | The client contract generated SDKs type-check against |
 | [src/utils.ts](src/utils.ts)                             | Config merging, URL building, auth, interceptors      |
-| [src/core/](src/core)                                    | OpenAPI path/query/body serializers                   |
+| [src/core/](src/core)                                    | OpenAPI path/query/body serializers, SSE streaming     |
 | [src/generate.ts](src/generate.ts)                       | Codegen and rewiring of generated output              |
 | [src/cli.ts](src/cli.ts)                                 | The `heyapi-grab` command                             |
 
-Serialization in `src/core/` is ported from Hey API's client core (MIT) so generated SDKs produce identical URLs and bodies on any client.
+Serialization and SSE streaming in `src/core/` are ported from Hey API's client core (MIT) so generated SDKs produce identical URLs, bodies and event streams on any client.

--- a/packages/heyapi-client-grab/src/client.ts
+++ b/packages/heyapi-client-grab/src/client.ts
@@ -10,6 +10,7 @@
 import { grab as defaultGrab } from "grab-url";
 import type { GrabOptions } from "grab-url";
 
+import { createSseClient } from "./core/sse";
 import type { Client, Config, RequestOptions, ResponseStyle } from "./types";
 import {
   buildUrl,
@@ -283,6 +284,53 @@ export const createClient = (config: Config = {}): Client => {
       : { error, request, response }) as any;
   };
 
+  // SSE opens a long-lived connection, so it goes straight through fetch
+  // rather than grab — grab's cache/retry/timeout model is built around a
+  // request that completes, not one that stays open and gets reconnected.
+  const makeSse =
+    (method: NonNullable<Config["method"]>): Client["sse"]["connect"] =>
+    async (options) => {
+      const opts = {
+        ..._config,
+        ...options,
+        headers: mergeHeaders(_config.headers, options.headers),
+      };
+
+      if (opts.security) await setAuthParams({ ...opts, security: opts.security });
+
+      let serializedBody: BodyInit | undefined;
+      if (opts.body !== undefined && opts.bodySerializer)
+        serializedBody = opts.bodySerializer(opts.body);
+      if (opts.body === undefined || serializedBody === "")
+        opts.headers.delete("Content-Type");
+
+      const requestOptions = { ...opts, method } as unknown as RequestOptions;
+      const url = buildUrl(requestOptions);
+
+      return createSseClient({
+        ...toRequestInit(opts),
+        fetch: opts.fetch,
+        headers: opts.headers,
+        method,
+        onRequest: async (reqUrl, init) => {
+          let sseRequest = new Request(reqUrl, init);
+          for (const fn of interceptors.request._fns)
+            if (fn) sseRequest = await fn(sseRequest, requestOptions);
+          return sseRequest;
+        },
+        onSseError: opts.onSseError,
+        onSseEvent: opts.onSseEvent,
+        responseTransformer: opts.responseTransformer,
+        responseValidator: opts.responseValidator,
+        serializedBody,
+        sseDefaultRetryDelay: opts.sseDefaultRetryDelay,
+        sseMaxRetryAttempts: opts.sseMaxRetryAttempts,
+        sseMaxRetryDelay: opts.sseMaxRetryDelay,
+        sseSleepFn: opts.sseSleepFn,
+        url,
+      });
+    };
+
   return {
     buildUrl: (options) => buildUrl({ ..._config, ...options } as any),
     connect: (options) => request({ ...options, method: "CONNECT" }),
@@ -297,6 +345,17 @@ export const createClient = (config: Config = {}): Client => {
     put: (options) => request({ ...options, method: "PUT" }),
     request,
     setConfig,
+    sse: {
+      connect: makeSse("CONNECT"),
+      delete: makeSse("DELETE"),
+      get: makeSse("GET"),
+      head: makeSse("HEAD"),
+      options: makeSse("OPTIONS"),
+      patch: makeSse("PATCH"),
+      post: makeSse("POST"),
+      put: makeSse("PUT"),
+      trace: makeSse("TRACE"),
+    },
     trace: (options) => request({ ...options, method: "TRACE" }),
   };
 };

--- a/packages/heyapi-client-grab/src/core/sse.ts
+++ b/packages/heyapi-client-grab/src/core/sse.ts
@@ -1,0 +1,229 @@
+/**
+ * @file sse.ts
+ * @description Server-sent event streaming. Opens a `text/event-stream`
+ * connection with `fetch` directly — SSE is a long-lived connection, not a
+ * single request/response, so it bypasses grab's cache/retry/rate-limit
+ * model rather than trying to fit inside it. Reconnects with exponential
+ * backoff (honoring the server's `retry:` field and `Last-Event-ID`) until
+ * the stream ends normally or the request is aborted.
+ *
+ * Ported from Hey API's client core (MIT) so an SSE endpoint behaves the
+ * same on this client as it does on `@hey-api/client-fetch`.
+ */
+
+import type { Config } from "../types";
+
+/** One event parsed off the wire. */
+export interface StreamEvent<TData = unknown> {
+  data: TData;
+  event?: string;
+  id?: string;
+  retry?: number;
+}
+
+/** Options accepted by {@link createSseClient}. */
+export type ServerSentEventsOptions<TData = unknown> = Omit<
+  RequestInit,
+  "method"
+> &
+  Pick<Config, "method" | "responseTransformer" | "responseValidator"> & {
+    /** Fetch implementation to use. default=globalThis.fetch */
+    fetch?: typeof fetch;
+    /** Called before each connection attempt so interceptors can rewrite the request. */
+    onRequest?: (url: string, init: RequestInit) => Promise<Request>;
+    /** Called when a connection attempt fails, before it retries. */
+    onSseError?: (error: unknown) => void;
+    /** Called for every event streamed from the server. */
+    onSseEvent?: (event: StreamEvent<TData>) => void;
+    /** Body already run through `bodySerializer`. */
+    serializedBody?: RequestInit["body"];
+    /** default=3000 Delay before the first retry, in ms. */
+    sseDefaultRetryDelay?: number;
+    /** Give up after this many retry attempts. */
+    sseMaxRetryAttempts?: number;
+    /** default=30000 Cap on the exponential backoff delay, in ms. */
+    sseMaxRetryDelay?: number;
+    /** Overrides the retry backoff wait. default=setTimeout-based sleep */
+    sseSleepFn?: (ms: number) => Promise<void>;
+    url: string;
+  };
+
+/** What {@link createSseClient} returns: an async generator of parsed event data. */
+export type ServerSentEventsResult<
+  TData = unknown,
+  TReturn = void,
+  TNext = unknown,
+> = {
+  stream: AsyncGenerator<
+    TData extends Record<string, unknown> ? TData[keyof TData] : TData,
+    TReturn,
+    TNext
+  >;
+};
+
+/**
+ * Opens a `text/event-stream` connection and yields each event's parsed
+ * `data`.
+ *
+ * @param options - Request to open, plus SSE-specific callbacks and retry settings.
+ * @returns An object holding the `stream` async generator.
+ */
+export function createSseClient<TData = unknown>({
+  onRequest,
+  onSseError,
+  onSseEvent,
+  responseTransformer,
+  responseValidator,
+  sseDefaultRetryDelay,
+  sseMaxRetryAttempts,
+  sseMaxRetryDelay,
+  sseSleepFn,
+  url,
+  ...options
+}: ServerSentEventsOptions<TData>): ServerSentEventsResult<TData> {
+  let lastEventId: string | undefined;
+
+  const sleep =
+    sseSleepFn ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+  const createStream = async function* () {
+    let retryDelay = sseDefaultRetryDelay ?? 3000;
+    let attempt = 0;
+    const signal = options.signal ?? new AbortController().signal;
+
+    while (true) {
+      if (signal.aborted) break;
+
+      attempt++;
+
+      const headers =
+        options.headers instanceof Headers
+          ? options.headers
+          : new Headers(options.headers as Record<string, string> | undefined);
+
+      if (lastEventId !== undefined) headers.set("Last-Event-ID", lastEventId);
+
+      try {
+        const requestInit: RequestInit = {
+          redirect: "follow",
+          ...options,
+          body: options.serializedBody as BodyInit | null | undefined,
+          headers,
+          signal,
+        };
+        let request = new Request(url, requestInit);
+        if (onRequest) request = await onRequest(url, requestInit);
+
+        // fetch must be assigned here, otherwise it throws:
+        // TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
+        const _fetch = options.fetch ?? globalThis.fetch;
+        const response = await _fetch(request);
+
+        if (!response.ok)
+          throw new Error(`SSE failed: ${response.status} ${response.statusText}`);
+        if (!response.body) throw new Error("No body in SSE response");
+
+        const reader = response.body
+          .pipeThrough(new TextDecoderStream())
+          .getReader();
+
+        let buffer = "";
+
+        const abortHandler = () => {
+          try {
+            reader.cancel();
+          } catch {
+            // noop
+          }
+        };
+
+        signal.addEventListener("abort", abortHandler);
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += value;
+            buffer = buffer.replace(/\r\n?/g, "\n"); // normalize line endings
+
+            const chunks = buffer.split("\n\n");
+            buffer = chunks.pop() ?? "";
+
+            for (const chunk of chunks) {
+              const lines = chunk.split("\n");
+              const dataLines: string[] = [];
+              let eventName: string | undefined;
+
+              for (const line of lines) {
+                if (line.startsWith("data:"))
+                  dataLines.push(line.replace(/^data:\s*/, ""));
+                else if (line.startsWith("event:"))
+                  eventName = line.replace(/^event:\s*/, "");
+                else if (line.startsWith("id:"))
+                  lastEventId = line.replace(/^id:\s*/, "");
+                else if (line.startsWith("retry:")) {
+                  const parsed = Number.parseInt(
+                    line.replace(/^retry:\s*/, ""),
+                    10,
+                  );
+                  if (!Number.isNaN(parsed)) retryDelay = parsed;
+                }
+              }
+
+              let data: unknown;
+              let parsedJson = false;
+
+              if (dataLines.length) {
+                const rawData = dataLines.join("\n");
+                try {
+                  data = JSON.parse(rawData);
+                  parsedJson = true;
+                } catch {
+                  data = rawData;
+                }
+              }
+
+              if (parsedJson) {
+                if (responseValidator) await responseValidator(data);
+                if (responseTransformer) data = await responseTransformer(data);
+              }
+
+              onSseEvent?.({
+                data: data as TData,
+                event: eventName,
+                id: lastEventId,
+                retry: retryDelay,
+              });
+
+              if (dataLines.length) yield data as any;
+            }
+          }
+        } finally {
+          signal.removeEventListener("abort", abortHandler);
+          reader.releaseLock();
+        }
+
+        break; // exit loop on normal completion
+      } catch (error) {
+        // connection failed or aborted; retry after delay
+        onSseError?.(error);
+
+        if (
+          sseMaxRetryAttempts !== undefined &&
+          attempt >= sseMaxRetryAttempts
+        )
+          break; // stop after firing error
+
+        // exponential backoff, capped at sseMaxRetryDelay
+        const backoff = Math.min(
+          retryDelay * 2 ** (attempt - 1),
+          sseMaxRetryDelay ?? 30000,
+        );
+        await sleep(backoff);
+      }
+    }
+  };
+
+  return { stream: createStream() };
+}

--- a/packages/heyapi-client-grab/src/index.ts
+++ b/packages/heyapi-client-grab/src/index.ts
@@ -19,6 +19,8 @@ export {
   serializeObjectParam,
   serializePrimitiveParam,
 } from "./core/path-serializer";
+export { createSseClient } from "./core/sse";
+export type { ServerSentEventsResult, StreamEvent } from "./core/sse";
 export { generateFromOpenAPI, rewireGeneratedClient } from "./generate";
 export type { GenerateOptions, GenerateResult } from "./generate";
 export type {

--- a/packages/heyapi-client-grab/src/types.ts
+++ b/packages/heyapi-client-grab/src/types.ts
@@ -8,6 +8,13 @@
 
 import type { GrabFunction } from "grab-url";
 
+import type {
+  ServerSentEventsOptions,
+  ServerSentEventsResult,
+  StreamEvent,
+} from "./core/sse";
+export type { StreamEvent, ServerSentEventsResult } from "./core/sse";
+
 /** Return only `data`, or the full `{ data, error, request, response }` set. */
 export type ResponseStyle = "data" | "fields";
 
@@ -92,6 +99,13 @@ export interface GrabConfig {
   parseDOM?: string | boolean;
   /** default=false Unescape HTML entities in text responses */
   unescapeHTML?: boolean;
+  /**
+   * Fetch implementation used only by `client.sse.*()`. Plain requests still
+   * go through grab or `GrabConfig.grab` — SSE's long-lived connection
+   * doesn't fit grab's request model, so it calls fetch directly.
+   * default=globalThis.fetch
+   */
+  fetch?: typeof fetch;
 }
 
 /** Client-wide configuration, also accepted per request. */
@@ -159,9 +173,19 @@ export interface RequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends Config<{
-    responseStyle: TResponseStyle;
-    throwOnError: ThrowOnError;
-  }> {
+      responseStyle: TResponseStyle;
+      throwOnError: ThrowOnError;
+    }>,
+    Pick<
+      ServerSentEventsOptions,
+      | "onRequest"
+      | "onSseError"
+      | "onSseEvent"
+      | "sseDefaultRetryDelay"
+      | "sseMaxRetryAttempts"
+      | "sseMaxRetryDelay"
+      | "sseSleepFn"
+    > {
   /** Request body, serialized with `bodySerializer`. */
   body?: unknown;
   /** Values for `{placeholders}` in the url. */
@@ -316,6 +340,16 @@ type RequestFn = <
     Pick<Required<RequestOptions<TResponseStyle, ThrowOnError>>, "method">,
 ) => RequestResult<TData, TError, ThrowOnError, TResponseStyle>;
 
+type SseFn = <
+  TData = unknown,
+  ThrowOnError extends boolean = false,
+  TResponseStyle extends ResponseStyle = "fields",
+>(
+  options: Omit<RequestOptions<TResponseStyle, ThrowOnError>, "method" | "onSseEvent"> & {
+    onSseEvent?: (event: StreamEvent<TData>) => void;
+  },
+) => Promise<ServerSentEventsResult<TData>>;
+
 type BuildUrlFn = <
   TData extends {
     body?: unknown;
@@ -343,6 +377,22 @@ export interface Client {
   put: MethodFn;
   request: RequestFn;
   setConfig: (config: Config) => Config;
+  /**
+   * Server-sent event endpoints — one method per HTTP verb, each returning
+   * `{ stream }`, an async generator of parsed event data. Connects with
+   * `fetch` directly rather than through grab; see `GrabConfig.fetch`.
+   */
+  sse: {
+    connect: SseFn;
+    delete: SseFn;
+    get: SseFn;
+    head: SseFn;
+    options: SseFn;
+    patch: SseFn;
+    post: SseFn;
+    put: SseFn;
+    trace: SseFn;
+  };
   trace: MethodFn;
 }
 

--- a/test/heyapi.test.ts
+++ b/test/heyapi.test.ts
@@ -44,7 +44,9 @@ const client = createClient(createConfig({ baseUrl: BASE, debug: false }));
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // mockReset (not just clearAllMocks) so a once-queue left over from a test
+  // that errors out mid-stream never leaks its remaining entries forward.
+  mockFetch.mockReset();
   grab.log = [];
   grab.mock = {};
   grab.defaults = {};
@@ -274,6 +276,114 @@ describe('auth and interceptors', () => {
       client.buildUrl({ path: { petId: '9' }, query: { full: true }, url: '/pets/{petId}' }),
     ).toBe(`${BASE}/pets/9?full=true`);
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Server-sent events ───────────────────────────────────────────────────────
+
+/** Queues a `text/event-stream` response built from raw SSE frame text. */
+function mockSse(body: string, status = 200) {
+  mockFetch.mockResolvedValueOnce(
+    new Response(body, {
+      status,
+      headers: { 'Content-Type': 'text/event-stream' },
+    }),
+  );
+}
+
+describe('server-sent events', () => {
+  it('streams parsed data events in order', async () => {
+    mockSse(
+      'data: {"progress":1}\n\n' + 'event: done\ndata: {"progress":2}\n\n',
+    );
+
+    const { stream } = await client.sse.get({ url: '/jobs/1/events' });
+
+    const events: unknown[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(events).toEqual([{ progress: 1 }, { progress: 2 }]);
+    const sentRequest = mockFetch.mock.calls[0]?.[0] as Request;
+    expect(sentRequest.url).toBe(`${BASE}/jobs/1/events`);
+    expect(sentRequest.method).toBe('GET');
+  });
+
+  it('reports event, id and retry metadata through onSseEvent', async () => {
+    mockSse('event: progress\nid: 42\nretry: 5000\ndata: {"pct":50}\n\n');
+
+    const seen: unknown[] = [];
+    const { stream } = await client.sse.get({
+      onSseEvent: (event) => seen.push(event),
+      url: '/jobs/1/events',
+    });
+    for await (const _ of stream);
+
+    expect(seen).toEqual([
+      { data: { pct: 50 }, event: 'progress', id: '42', retry: 5000 },
+    ]);
+  });
+
+  it('sends the Last-Event-ID header on a reconnect', async () => {
+    // First connection delivers one event, then the stream itself breaks
+    // (a normal end-of-stream never triggers a reconnect, only an error does).
+    let pulls = 0;
+    const droppedBody = new ReadableStream({
+      pull(controller) {
+        pulls++;
+        if (pulls === 1) {
+          controller.enqueue(new TextEncoder().encode('id: 1\ndata: {"n":1}\n\n'));
+        } else {
+          controller.error(new Error('connection reset'));
+        }
+      },
+    });
+    mockFetch.mockResolvedValueOnce(
+      new Response(droppedBody, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+    mockSse('data: {"n":2}\n\n');
+
+    const { stream } = await client.sse.get({
+      sseSleepFn: () => Promise.resolve(),
+      url: '/jobs/1/events',
+    });
+
+    const events: unknown[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(events).toEqual([{ n: 1 }, { n: 2 }]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((mockFetch.mock.calls[1]?.[0] as Request).headers.get('Last-Event-ID')).toBe('1');
+  });
+
+  it('gives up after sseMaxRetryAttempts and reports the error', async () => {
+    mockFetch.mockRejectedValue(new Error('down'));
+
+    const errors: unknown[] = [];
+    const { stream } = await client.sse.get({
+      onSseError: (error) => errors.push(error),
+      sseMaxRetryAttempts: 2,
+      sseSleepFn: () => Promise.resolve(),
+      url: '/jobs/1/events',
+    });
+
+    const events: unknown[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(events).toEqual([]);
+    expect(errors).toHaveLength(2);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not go through grab', async () => {
+    mockSse('data: {"ok":true}\n\n');
+
+    const { stream } = await client.sse.get({ url: '/jobs/1/events' });
+    for await (const _ of stream);
+
+    expect(grab.log).toHaveLength(0);
   });
 });
 

--- a/test/heyapi.test.ts
+++ b/test/heyapi.test.ts
@@ -385,6 +385,61 @@ describe('server-sent events', () => {
 
     expect(grab.log).toHaveLength(0);
   });
+
+  it('applies a bearer token from the security scheme', async () => {
+    mockSse('data: {"ok":true}\n\n');
+
+    const authed = createClient(
+      createConfig({ auth: () => 'secret', baseUrl: BASE, debug: false }),
+    );
+
+    const { stream } = await authed.sse.get({
+      security: [{ scheme: 'bearer', type: 'http' }],
+      url: '/jobs/1/events',
+    });
+    for await (const _ of stream);
+
+    const sentRequest = mockFetch.mock.calls[0]?.[0] as Request;
+    expect(sentRequest.headers.get('Authorization')).toBe('Bearer secret');
+  });
+
+  it('runs request interceptors before connecting', async () => {
+    mockSse('data: {"ok":true}\n\n');
+
+    const scoped = createClient(createConfig({ baseUrl: BASE, debug: false }));
+    scoped.interceptors.request.use((request) => {
+      const next = new Request(request);
+      next.headers.set('X-Trace', 'on');
+      return next;
+    });
+
+    const { stream } = await scoped.sse.get({ url: '/jobs/1/events' });
+    for await (const _ of stream);
+
+    const sentRequest = mockFetch.mock.calls[0]?.[0] as Request;
+    expect(sentRequest.headers.get('X-Trace')).toBe('on');
+  });
+
+  it('reports a non-ok response as an SSE error', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(null, { status: 503, statusText: 'Service Unavailable' }),
+    );
+
+    const errors: unknown[] = [];
+    const { stream } = await client.sse.get({
+      onSseError: (error) => errors.push(error),
+      sseMaxRetryAttempts: 1,
+      sseSleepFn: () => Promise.resolve(),
+      url: '/jobs/1/events',
+    });
+
+    const events: unknown[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(events).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe('SSE failed: 503 Service Unavailable');
+  });
 });
 
 // ─── Codegen rewiring ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`heyapi-client-grab`'s README used to say: *"No `sse` helpers. Server-sent event endpoints need the fetch client."* This PR closes that gap.

- Adds `client.sse.<method>()` (one per HTTP verb) to the grab-powered Hey API client, matching the surface `@hey-api/openapi-ts` generates for an operation whose response is `text/event-stream`. A generated SDK function for such an operation now works unchanged when rewired to this client.
- SSE opens a long-lived connection rather than a single request/response, so it goes straight through `fetch` instead of grab — grab's cache/retry/rate-limit/timeout model is built around a request that completes, not one that stays open and reconnects. This mirrors how `@hey-api/client-fetch`'s own SSE support works.
- Reconnects with exponential backoff on a network or parse error, honoring the server's `retry:` field and sending `Last-Event-ID` from the last event's `id:` — matching browser `EventSource` semantics. A stream that ends normally does not reconnect.
- New `src/core/sse.ts` (`createSseClient`, `StreamEvent`, `ServerSentEventsOptions`, `ServerSentEventsResult`), ported from Hey API's client core (MIT), consistent with how `src/core/` already ports the path/body serializers.
- `ServerSentEventsResult` and `StreamEvent` are exported from the package so generated code (which imports `ServerSentEventsResult` as the SSE return type) and user code type-check.

## Test plan

- [x] `npx tsc --noEmit` in `packages/heyapi-client-grab` — clean
- [x] `npx vite build` in `packages/heyapi-client-grab` — builds and generates declarations cleanly
- [x] `npx vitest run` at the repo root — 140/140 tests pass, including 5 new SSE tests covering: parsed event streaming in order, `onSseEvent` metadata (`event`/`id`/`retry`), `Last-Event-ID` sent on reconnect after a mid-stream error, giving up after `sseMaxRetryAttempts`, and confirming SSE requests bypass grab (`grab.log` stays empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AZVEbU8Xhe95yzDyh1TA8

---
_Generated by [Claude Code](https://claude.ai/code/session_017AZVEbU8Xhe95yzDyh1TA8)_