### PR TITLE
feat(cli): SFTP, torrent and magnet transfers via aria2c, plus background jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ npm i grab-url
 **CLI File Downloader**
 ```bash
 npx grab-url https://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-live-server-amd64.iso
+
+# SFTP, torrents and magnet links (needs aria2c installed)
+npx grab-url sftp://user@host/srv/backup.tar.gz --password hunter2
+npx grab-url "magnet:?xt=urn:btih:HASH" -d ./downloads
+
+# Detach and keep going in the background; Ctrl+C on any transfer offers the same
+npx grab-url https://example.com/big.iso --background
+npx grab-url --jobs
 ```
 
 

--- a/packages/grab-url-cli/README.md
+++ b/packages/grab-url-cli/README.md
@@ -1,6 +1,6 @@
 # @grab-url/cli
 
-CLI front end for [`grab-url`](https://grab.js.org). Fetches API responses or downloads files — auto-detecting which mode to use based on the URL — with colored multi-file progress bars, resumable transfers, and keyboard controls.
+CLI front end for [`grab-url`](https://grab.js.org). Fetches API responses, downloads files over HTTP(S), and transfers over **SFTP**, **BitTorrent** and **magnet** links — auto-detecting which mode to use from the URL — with colored multi-file progress bars, resumable transfers, keyboard controls, and detachable background jobs.
 
 ```bash
 npx grab-url <url> [options]
@@ -26,6 +26,19 @@ npx grab-url https://api.example.com/search -p '{"q":"hello","limit":10}'
 
 # Print to stdout instead of writing a file
 npx grab-url https://api.example.com/data --no-save
+
+# Pull a file over SFTP (aria2c)
+npx grab-url sftp://user@host/srv/backup.tar.gz --password hunter2
+
+# Download a torrent or a magnet link into ./downloads
+npx grab-url ./ubuntu.torrent -d ./downloads
+npx grab-url "magnet:?xt=urn:btih:HASH" -d ./downloads --seed
+
+# Detach immediately and keep transferring in the background
+npx grab-url https://example.com/big.iso --background
+
+# See what is still running in the background
+npx grab-url --jobs
 ```
 
 ## Options
@@ -35,10 +48,109 @@ npx grab-url https://api.example.com/data --no-save
 | `--output <file>`   | `-o`  | string  | Output filename (default: `output.json` for APIs, derived from URL for files) |
 | `--params <json>`   | `-p`  | string  | JSON string of query parameters, e.g. `'{"key":"value"}'`                 |
 | `--no-save`         |       | boolean | Don't save output to a file — just print to console                       |
+| `--background`      | `-b`  | boolean | Detach at once and keep transferring in the background, logging to a file  |
+| `--jobs`            |       | boolean | List background transfers that are still running, then exit                |
+| `--log <file>`      |       | string  | Log file for background transfers (default: `<state-dir>/logs/`)          |
+| `--no-bg-prompt`    |       | boolean | On Ctrl+C, cancel right away instead of offering the background handoff    |
+| `--dir <path>`      | `-d`  | string  | Destination directory for downloads and sftp / torrent / magnet transfers  |
+| `--seed`            |       | boolean | Keep seeding a torrent after it completes (default: stop at 100%)          |
+| `--connections <n>` | `-c`  | number  | Connections per server for SFTP transfers, 1–16 (default 8)                |
+| `--user <name>`     |       | string  | Username for SFTP transfers                                                |
+| `--password <pw>`   |       | string  | Password for SFTP transfers                                                |
+| `--ssh-host-key <d>`|       | string  | Expected SFTP host key digest, e.g. `sha-1=b030503…` — aborts on mismatch  |
+| `--aria2-args <s>`  |       | string  | Extra space-separated flags passed straight to `aria2c`                    |
 | `--help`            | `-h`  |         | Show help                                                                  |
 | `--version`         |       |         | Show version                                                               |
 
 The CLI auto-detects **download mode** when more than one URL is passed or any URL looks like a file. Otherwise it runs in **API mode** and tries to parse JSON.
+
+## SFTP, torrents and magnet links
+
+`fetch()` cannot speak SFTP or BitTorrent, so those targets are handed to
+[`aria2c`](https://aria2.github.io/), whose progress readout is parsed and shown in the same
+progress bar as every other transfer. A target is routed to aria2c when it is:
+
+| Target                                | Kind      |
+| ------------------------------------- | --------- |
+| `sftp://user@host/path/file`          | `sftp`    |
+| `magnet:?xt=urn:btih:…`               | `magnet`  |
+| anything ending in `.torrent` (local path or URL) | `torrent` |
+
+Everything else keeps using the built-in `fetch()` downloader, and a single command can mix
+both: `grab-url https://a/f.iso ./b.torrent` downloads the torrent first, then the file.
+
+**aria2c is required for these three kinds.** When it is missing, the CLI says so and prints the
+install command for your platform (`brew install aria2`, `sudo apt install aria2`,
+`winget install aria2.aria2`). Set `GRAB_ARIA2_PATH` to use a binary that is not on `PATH`. SFTP
+and BitTorrent are compile-time features of aria2c, so a build without them is rejected up front
+with the feature list it does have.
+
+```bash
+# Credentials inline, or as flags (flags keep them out of shell history files)
+grab-url sftp://alice:hunter2@host:2222/srv/db.tar.zst
+grab-url sftp://host:2222/srv/db.tar.zst --user alice --password hunter2
+
+# Pin the host key; the transfer aborts if the server presents a different one
+grab-url sftp://host/srv/db.tar.zst --user alice --password hunter2 \
+  --ssh-host-key sha-1=b030503bb45f9f0e0a1e9c4a1e0b8f4c3d2e1f00
+
+# Rename the downloaded file (sftp only — torrents carry their own names)
+grab-url sftp://host/srv/db.tar.zst -o backup.tar.zst
+
+# Throttle, or pass any other aria2c flag straight through
+grab-url ./ubuntu.torrent --aria2-args "--max-overall-download-limit=2M --enable-dht=false"
+```
+
+Passwords are redacted (`sftp://alice:***@host`) everywhere the CLI echoes a URI — console
+output, background logs and the job registry.
+
+Interrupted transfers resume: aria2c keeps a `.aria2` control file next to the download, so
+re-running the same command picks up where it stopped.
+
+## Background transfers
+
+Long transfers do not have to hold your terminal.
+
+```bash
+# Start detached right away — prints the PID and log path, then returns
+grab-url https://example.com/big.iso --background
+
+# List what is still running (dead jobs are pruned automatically)
+grab-url --jobs
+
+# Follow one, or stop it
+tail -f .grab-downloads/logs/big.iso-….log
+kill <pid>
+```
+
+Press **Ctrl+C** during any transfer and the CLI asks before it throws the work away:
+
+```
+🛑 Cancel — keep transferring in the background? [Y/n]
+```
+
+- **y** (or Enter) — the transfer is handed to a detached process that resumes from the partial
+  file, and you get its PID and log path. The prompt auto-accepts after 15 seconds so a
+  disconnected terminal does not strand the download.
+- **n** — the transfer stops. The partial file and its resume state stay on disk, so running the
+  same command again continues from there.
+
+Ctrl+C a second time while the prompt is up answers **n**. `--no-bg-prompt` skips the question
+entirely, and non-interactive shells (pipes, CI) always cancel outright.
+
+Backgrounding re-launches the same command as a detached child rather than migrating live
+sockets, so it relies on the same resume machinery as any interrupted transfer: HTTP transfers
+resume when the server supports range requests, and SFTP/torrent transfers resume from aria2c's
+control file. Job records and logs live under the download state directory
+(`.grab-downloads/` by default, or `GRAB_DOWNLOAD_STATE_DIR`).
+
+## Keyboard controls
+
+| Key      | Action                                                    |
+| -------- | --------------------------------------------------------- |
+| `p`      | Pause / resume every transfer (aria2c children included)   |
+| `a`      | Prompt for another URL to add to the running session       |
+| `Ctrl+C` | Cancel — with the option to keep going in the background  |
 
 ## Programmatic API
 
@@ -68,10 +180,12 @@ await downloader.downloadMultipleFiles([
 | [index.ts](index.ts)                            | CLI entry point — argv parsing, mode detection, dispatch           |
 | [cli-args.ts](cli-args.ts)                      | Minimal `ArgParser` (yargs-like) and `isFileUrl` detection          |
 | [file-downloader.ts](file-downloader.ts)        | `MultiColorFileDownloaderCLI` — concurrent download orchestrator    |
+| [background.ts](background.ts)                  | Detached background jobs, the job registry, and the cancel prompt   |
+| [cancel-state.ts](cancel-state.ts)              | Shared "user is cancelling" flag that quiets abort-induced errors   |
 | [keyboard-controls.ts](keyboard-controls.ts)    | Pause / resume / cancel keybindings while downloads run            |
 | [download-spinners.ts](download-spinners.ts)    | Spinner frames used by progress bars                               |
 | [display/](display/)                            | Progress bar formatting and spinner configuration                  |
-| [transfer/](transfer/)                          | Single-file & multi-file transfer engines plus resume-state logic  |
+| [transfer/](transfer/)                          | Single-file & multi-file transfer engines, resume state, and the aria2c bridge |
 
 ## Dependencies
 
@@ -79,6 +193,7 @@ await downloader.downloadMultipleFiles([
 - [`cli-progress`](https://github.com/npkgz/cli-progress) — multi-bar progress UI
 - [`cli-table3`](https://github.com/cli-table/cli-table3) — final stats table
 - [`@grab-url/loading-animations`](../loading-animations) — spinner frame data
+- [`aria2c`](https://aria2.github.io/) — *external binary*, only needed for SFTP, torrent and magnet transfers
 
 ## License
 

--- a/packages/grab-url-cli/src/background.ts
+++ b/packages/grab-url-cli/src/background.ts
@@ -1,0 +1,254 @@
+/**
+ * @file background.ts
+ * @description Detached background transfers plus the job registry behind
+ * `--background`, the Ctrl+C "keep running in background?" prompt, and `--jobs`.
+ *
+ * A running transfer cannot hand its sockets to another process, so
+ * "backgrounding" re-launches the same command as a detached child. Both the
+ * HTTP downloader (`.tmp` + `.download-state` sidecar) and aria2c (`.aria2`
+ * control file) resume from disk, so the child picks up where the foreground
+ * run stopped.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+
+import { colors, formatBytesPlain } from './display/progress-format.js';
+import { redactCredentials } from './transfer/aria2-transfer.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface JobRecord {
+    pid: number;
+    /** Targets being transferred. */
+    urls: string[];
+    /** Absolute path of the log file the detached process writes to. */
+    log: string;
+    /** Working directory the job was started from. */
+    cwd: string;
+    /** ISO timestamp of when the job was detached. */
+    started: string;
+    /** "flag" when started with --background, "cancel" when handed off by Ctrl+C. */
+    reason: 'flag' | 'cancel';
+}
+
+export interface DetachOptions {
+    /** Directory holding logs + job records (defaults to the download state dir). */
+    stateDir: string;
+    /** Targets, used for the job record and re-invocation. */
+    urls: string[];
+    /** Explicit log path; one is generated under `<stateDir>/logs` when omitted. */
+    logFile?: string | null;
+    /** Why the job is being detached. */
+    reason?: 'flag' | 'cancel';
+    /** argv to re-run with (defaults to the current process argv). */
+    argv?: string[];
+}
+
+/** Internal flag added to the re-invoked argv so the child never re-detaches. */
+export const BACKGROUND_CHILD_FLAG = '--grab-background-child';
+
+// ─── Argv helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Strip foreground-only flags from an argv list and append the child marker, so
+ * the detached process runs the same transfer without detaching again.
+ *
+ * @param argv - User arguments (i.e. `process.argv.slice(2)`)
+ */
+export function buildChildArgv(argv: string[]): string[] {
+    const dropped = new Set(['--background', '-b', BACKGROUND_CHILD_FLAG]);
+    const cleaned = argv.filter((arg) => !dropped.has(arg) && !/^--background=/.test(arg));
+    return [...cleaned, BACKGROUND_CHILD_FLAG];
+}
+
+/** True when this process is itself a detached background child. */
+export function isBackgroundChild(argv: string[] = process.argv): boolean {
+    return argv.includes(BACKGROUND_CHILD_FLAG);
+}
+
+// ─── Job registry ─────────────────────────────────────────────────────────────
+
+/** Directory holding one JSON record per detached job. */
+export function getJobsDirectory(stateDir: string): string {
+    return path.join(stateDir, 'jobs');
+}
+
+/** Directory holding background job logs. */
+export function getLogsDirectory(stateDir: string): string {
+    return path.join(stateDir, 'logs');
+}
+
+/**
+ * Build the default log path for a background job.
+ */
+export function buildLogPath(stateDir: string, urls: string[]): string {
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const slug = (path.basename((urls[0] ?? 'grab').split('?')[0]) || 'grab')
+        .replace(/[^\w.-]/g, '_')
+        .slice(0, 40);
+    return path.join(getLogsDirectory(stateDir), `${slug}-${stamp}.log`);
+}
+
+/** Persist a job record so `--jobs` can list it later. */
+export function writeJobRecord(stateDir: string, job: JobRecord): void {
+    try {
+        const dir = getJobsDirectory(stateDir);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, `${job.pid}.json`), JSON.stringify(job, null, 2));
+    } catch { /* the registry is best-effort */ }
+}
+
+/** True when a pid belongs to a process that is still alive. */
+export function isProcessAlive(pid: number): boolean {
+    try { process.kill(pid, 0); return true; } catch (e: any) { return e?.code === 'EPERM'; }
+}
+
+/**
+ * Read all job records, dropping the ones whose process has exited.
+ *
+ * @param stateDir - Download state directory
+ * @param prune    - Delete records for finished jobs (default true)
+ */
+export function listJobs(stateDir: string, prune = true): JobRecord[] {
+    const dir = getJobsDirectory(stateDir);
+    let files: string[] = [];
+    try { files = fs.readdirSync(dir).filter((f) => f.endsWith('.json')); } catch { return []; }
+
+    const running: JobRecord[] = [];
+    for (const file of files) {
+        const full = path.join(dir, file);
+        try {
+            const job = JSON.parse(fs.readFileSync(full, 'utf8')) as JobRecord;
+            if (isProcessAlive(job.pid)) running.push(job);
+            else if (prune) fs.unlinkSync(full);
+        } catch {
+            if (prune) { try { fs.unlinkSync(full); } catch { /* ignore */ } }
+        }
+    }
+    return running.sort((a, b) => a.started.localeCompare(b.started));
+}
+
+/**
+ * Print the running background jobs, or a hint when there are none.
+ */
+export function printJobs(stateDir: string): void {
+    const jobs = listJobs(stateDir);
+    if (!jobs.length) {
+        console.log(colors.info('No background transfers running.'));
+        console.log(colors.info('Start one with: ') + 'grab <url> --background');
+        return;
+    }
+    console.log(colors.cyan.bold(`\n${jobs.length} background transfer${jobs.length > 1 ? 's' : ''}:`));
+    for (const job of jobs) {
+        let size = '';
+        try { size = ` (log ${formatBytesPlain(fs.statSync(job.log).size)})`; } catch { /* no log yet */ }
+        console.log(
+            colors.success(`  PID ${job.pid}`) + ' ' +
+            colors.yellow(job.urls.join(' ')) + '\n' +
+            colors.info(`    started ${new Date(job.started).toLocaleString()}  •  log: ${job.log}${size}`),
+        );
+    }
+    console.log(colors.info('\nFollow a log: ') + `tail -f <log>` + colors.info('   Stop a job: ') + 'kill <pid>\n');
+}
+
+// ─── Detaching ────────────────────────────────────────────────────────────────
+
+/**
+ * Re-launch the current command as a detached background process and register
+ * it as a job. The parent is expected to exit right after.
+ *
+ * @returns The child pid plus its log path, or null when spawning failed
+ */
+export function detachToBackground(opts: DetachOptions): { pid: number; log: string } | null {
+    const argv = buildChildArgv(opts.argv ?? process.argv.slice(2));
+    const logPath = opts.logFile
+        ? path.resolve(opts.logFile)
+        : buildLogPath(opts.stateDir, opts.urls);
+
+    try {
+        fs.mkdirSync(path.dirname(logPath), { recursive: true });
+        const logFd = fs.openSync(logPath, 'a');
+        const entry = process.argv[1];
+        const child = spawn(process.execPath, [entry, ...argv], {
+            cwd: process.cwd(),
+            detached: true,
+            stdio: ['ignore', logFd, logFd],
+            env: { ...process.env, FORCE_COLOR: '0', GRAB_BACKGROUND: '1' },
+        });
+        child.unref();
+        fs.closeSync(logFd);
+
+        const pid = child.pid ?? -1;
+        if (pid > 0) {
+            writeJobRecord(opts.stateDir, {
+                pid,
+                // The child gets the real argv; the record is only for display.
+                urls: opts.urls.map(redactCredentials),
+                log: logPath,
+                cwd: process.cwd(),
+                started: new Date().toISOString(),
+                reason: opts.reason ?? 'flag',
+            });
+        }
+        return { pid, log: logPath };
+    } catch (e: any) {
+        console.error(colors.error.bold('❌ Could not start background transfer: ') + e.message);
+        return null;
+    }
+}
+
+/**
+ * Print the standard "now running in the background" summary.
+ */
+export function reportDetached(handoff: { pid: number; log: string }): void {
+    console.log(colors.success(`\n🌙 Continuing in the background — PID ${handoff.pid}`));
+    console.log(colors.info('   Log:    ') + handoff.log);
+    console.log(colors.info('   Follow: ') + `tail -f ${handoff.log}`);
+    console.log(colors.info('   List:   ') + 'grab --jobs' + colors.info('    Stop: ') + `kill ${handoff.pid}`);
+}
+
+// ─── Cancel prompt ────────────────────────────────────────────────────────────
+
+/**
+ * Ask a yes/no question on a raw-mode TTY, resolving on a single keypress.
+ * Resolves to `defaultYes` on Enter, and false on Ctrl+C / Esc.
+ *
+ * @param question   - Text shown to the user
+ * @param defaultYes - Answer used when Enter is pressed (default true)
+ * @param timeoutMs  - Auto-answer with the default after this long (0 = never)
+ */
+export function promptYesNo(question: string, defaultYes = true, timeoutMs = 15000): Promise<boolean> {
+    const stdin = process.stdin as NodeJS.ReadStream;
+    if (!stdin.isTTY) return Promise.resolve(false);
+
+    const hint = defaultYes ? '[Y/n]' : '[y/N]';
+    process.stdout.write(colors.warning(`\n${question} ${hint} `));
+
+    const wasRaw = stdin.isRaw;
+    if (!wasRaw) stdin.setRawMode(true);
+    stdin.resume();
+
+    return new Promise<boolean>((resolve) => {
+        let settled = false;
+        const finish = (answer: boolean) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            stdin.removeListener('data', onData);
+            if (!wasRaw) stdin.setRawMode(false);
+            process.stdout.write(`${answer ? 'y' : 'n'}\n`);
+            resolve(answer);
+        };
+        const onData = (chunk: Buffer | string) => {
+            const key = chunk.toString();
+            if (key === '\r' || key === '\n') return finish(defaultYes);
+            if (key === '\u0003' || key === '\u001b') return finish(false);
+            if (/^[yY]/.test(key)) return finish(true);
+            if (/^[nN]/.test(key)) return finish(false);
+        };
+        const timer = timeoutMs > 0 ? setTimeout(() => finish(defaultYes), timeoutMs) : (null as any);
+        stdin.on('data', onData);
+    });
+}

--- a/packages/grab-url-cli/src/cancel-state.ts
+++ b/packages/grab-url-cli/src/cancel-state.ts
@@ -1,0 +1,22 @@
+/**
+ * @file cancel-state.ts
+ * @description One flag shared by the transfer engines and the CLI: is the user
+ * currently cancelling (possibly handing the transfer off to a background
+ * process)?
+ *
+ * A cancel aborts in-flight requests, which surfaces as ordinary download
+ * failures. Without this flag the CLI would print "Failed: 1/1" and an empty
+ * stats table right before reporting a successful background handoff.
+ */
+
+let cancelInProgress = false;
+
+/** Mark the start (or end) of a user-initiated cancellation. */
+export function setCancelInProgress(value: boolean): void {
+    cancelInProgress = value;
+}
+
+/** True while a cancellation or background handoff is underway. */
+export function isCancelInProgress(): boolean {
+    return cancelInProgress;
+}

--- a/packages/grab-url-cli/src/cli-args.ts
+++ b/packages/grab-url-cli/src/cli-args.ts
@@ -38,7 +38,11 @@ export class ArgParser {
         for (let i = 0; i < args.length; i++) {
             const arg = args[i];
             if (arg.startsWith('--')) {
-                const [key, value] = arg.split('=');
+                // Split on the FIRST '=' only, so values may contain '='
+                // (e.g. --aria2-args=--max-download-limit=1M)
+                const eq = arg.indexOf('=');
+                const key = eq === -1 ? arg : arg.slice(0, eq);
+                const value = eq === -1 ? undefined : arg.slice(eq + 1);
                 const optName = key.slice(2);
                 if (value !== undefined) {
                     result[optName] = this.coerceValue(optName, value);
@@ -46,7 +50,8 @@ export class ArgParser {
                     result[optName] = true;
                 } else {
                     const nextArg = args[i + 1];
-                    if (nextArg && !nextArg.startsWith('-')) {
+                    // `greedy` options (e.g. --aria2-args) accept dash-leading values
+                    if (nextArg !== undefined && (!nextArg.startsWith('-') || this.options[optName]?.greedy)) {
                         result[optName] = this.coerceValue(optName, nextArg);
                         i++;
                     } else {
@@ -61,7 +66,7 @@ export class ArgParser {
                         result[longName] = true;
                     } else {
                         const nextArg = args[i + 1];
-                        if (nextArg && !nextArg.startsWith('-')) {
+                        if (nextArg !== undefined && (!nextArg.startsWith('-') || this.options[longName]?.greedy)) {
                             result[longName] = this.coerceValue(longName, nextArg);
                             i++;
                         }
@@ -80,7 +85,11 @@ export class ArgParser {
             }
         });
 
-        if ((!result.urls || result.urls.length === 0) && this.commands.url?.required) {
+        // Options marked `standalone` (e.g. --jobs) run without any URL
+        const standaloneUsed = Object.keys(this.options)
+            .some(key => this.options[key].standalone && result[key]);
+
+        if ((!result.urls || result.urls.length === 0) && this.commands.url?.required && !standaloneUsed) {
             console.error('Error: Missing required argument: url');
             this.showHelp();
             process.exit(1);
@@ -113,6 +122,7 @@ export class ArgParser {
         console.log('\nOptions:');
         Object.keys(this.options).forEach(key => {
             const opt = this.options[key];
+            if (opt.hidden) return;
             const flags = opt.alias ? `-${opt.alias}, --${key}` : `--${key}`;
             console.log(`  ${flags.padEnd(20)} ${opt.describe || ''}`);
         });

--- a/packages/grab-url-cli/src/file-downloader.ts
+++ b/packages/grab-url-cli/src/file-downloader.ts
@@ -63,6 +63,8 @@ export class MultiColorFileDownloaderCLI {
     resumeCallback: (() => void) | null = null;
     isAddingUrl = false;
     stateDir: string;
+    /** Ctrl+C handler — when set it replaces the default "exit now" behavior. */
+    cancelHandler: (() => Promise<void> | void) | null = null;
 
     // Column constants (kept for backward compat)
     readonly COL_FILENAME = COL_FILENAME;
@@ -108,6 +110,12 @@ export class MultiColorFileDownloaderCLI {
     setPauseCallback(cb: () => void) { this.pauseCallback = cb; }
     setResumeCallback(cb: () => void) { this.resumeCallback = cb; }
 
+    /**
+     * Register what happens on Ctrl+C. The CLI uses it to ask whether the
+     * transfer should carry on in a detached background process.
+     */
+    setCancelHandler(cb: (() => Promise<void> | void) | null) { this.cancelHandler = cb; }
+
     pauseAll() {
         this.isPaused = true;
         console.log(colors.warning('⏸️  Pausing all downloads...'));
@@ -125,6 +133,7 @@ export class MultiColorFileDownloaderCLI {
         if (this.progressBar) this.progressBar.stop();
         if (this.multiBar) this.multiBar.stop();
         if (this.abortController) this.abortController.abort();
+        this.abortControllers.forEach(c => { try { c.abort(); } catch { } });
         teardownKeyboardListener();
     }
 
@@ -140,6 +149,7 @@ export class MultiColorFileDownloaderCLI {
             hasMultiBar: () => !!this.multiBar,
             addToMultipleDownloads: (u, o, f) => this.addToMultipleDownloads(u, o, f),
             downloadFile: (u, o) => this.downloadFile(u, o),
+            ...(this.cancelHandler ? { onCancel: () => this.cancelHandler!() } : {}),
         };
         setupKeyboardListener(cbs);
     }

--- a/packages/grab-url-cli/src/index.ts
+++ b/packages/grab-url-cli/src/index.ts
@@ -1,22 +1,42 @@
 /**
  * @file grab-url.ts
- * @description CLI entry point for grab-url. Supports API requests and file downloads.
+ * @description CLI entry point for grab-url. Supports API requests, file
+ * downloads, SFTP / BitTorrent / magnet transfers (via aria2c), and detached
+ * background jobs.
  *
  * Usage:
  *   npx grab-url <url> [options]
  *   npx grab-url https://api.example.com/data
  *   npx grab-url https://example.com/file.zip
+ *   npx grab-url sftp://user@host/path/file.iso
+ *   npx grab-url "magnet:?xt=urn:btih:..." --background
  */
 
 import fs from "fs";
 import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
+import type { ChildProcess } from "child_process";
 
 import chalk from "chalk";
 import Table from "cli-table3";
 
 import { ArgParser, isFileUrl } from "./cli-args.js";
 import { MultiColorFileDownloaderCLI } from "./file-downloader.js";
+import {
+  classifyAria2Target,
+  isAria2Target,
+  runAria2Transfer,
+} from "./transfer/aria2-transfer.js";
+import {
+  detachToBackground,
+  isBackgroundChild,
+  printJobs,
+  promptYesNo,
+  reportDetached,
+} from "./background.js";
+import { colors } from "./display/progress-format.js";
+import { getStateDirectory } from "./transfer/resume-state.js";
+import { isCancelInProgress, setCancelInProgress } from "./cancel-state.js";
 import grab, { log } from "../../grab-api/src/index.js";
 
 // ─── Library re-exports (for programmatic use) ──────────────────────────────
@@ -28,6 +48,27 @@ export {
   getFileExtension,
 } from "./keyboard-controls.js";
 export { ArgParser, isFileUrl } from "./cli-args.js";
+export {
+  classifyAria2Target,
+  isAria2Target,
+  buildAria2Args,
+  parseAria2Progress,
+  parseAria2Size,
+  parseAria2Eta,
+  findAria2,
+  runAria2Transfer,
+} from "./transfer/aria2-transfer.js";
+export type { Aria2Kind, Aria2Options } from "./transfer/aria2-transfer.js";
+export {
+  detachToBackground,
+  buildChildArgv,
+  isBackgroundChild,
+  listJobs,
+  printJobs,
+  promptYesNo,
+} from "./background.js";
+export type { JobRecord } from "./background.js";
+export { isCancelInProgress, setCancelInProgress } from "./cancel-state.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -47,7 +88,7 @@ const __isMain =
 if (__isMain) {
   const argv = new ArgParser()
     .usage("Usage: grab-url <url...> [options]")
-    .command("$0 <url>", "Fetch data or download files; pass one or more URLs")
+    .command("$0 <url>", "Fetch data, download files, or transfer sftp/torrent/magnet")
     .option("no-save", {
       type: "boolean",
       default: false,
@@ -72,6 +113,72 @@ if (__isMain) {
         }
       },
     })
+    .option("background", {
+      alias: "b",
+      type: "boolean",
+      default: false,
+      describe: "Detach and transfer in the background, logging to a file",
+    })
+    .option("jobs", {
+      type: "boolean",
+      default: false,
+      standalone: true,
+      describe: "List background transfers still running, then exit",
+    })
+    .option("log", {
+      type: "string",
+      default: null,
+      describe: "Log file for background transfers (default: <state-dir>/logs)",
+    })
+    .option("no-bg-prompt", {
+      type: "boolean",
+      default: false,
+      describe: "On Ctrl+C, cancel immediately instead of offering background",
+    })
+    .option("dir", {
+      alias: "d",
+      type: "string",
+      default: null,
+      describe: "Destination directory for downloads and sftp/torrent/magnet",
+    })
+    .option("seed", {
+      type: "boolean",
+      default: false,
+      describe: "Keep seeding a torrent after it completes",
+    })
+    .option("connections", {
+      alias: "c",
+      type: "number",
+      default: 8,
+      describe: "Connections per server for sftp transfers (1-16)",
+    })
+    .option("user", {
+      type: "string",
+      default: null,
+      describe: "Username for sftp transfers",
+    })
+    .option("password", {
+      type: "string",
+      default: null,
+      describe: "Password for sftp transfers",
+    })
+    .option("ssh-host-key", {
+      type: "string",
+      default: null,
+      describe: "Expected sftp host key digest, e.g. sha-1=b030503...",
+    })
+    .option("aria2-args", {
+      type: "string",
+      default: null,
+      greedy: true,
+      describe: "Extra space-separated flags passed straight to aria2c",
+    })
+    .option("grab-background-child", {
+      type: "boolean",
+      default: false,
+      hidden: true,
+      describe: "Internal: marks a detached background process",
+    })
     .help()
     .alias("h", "help")
     .example(
@@ -86,7 +193,20 @@ if (__isMain) {
       "grab-url https://example.com/file.iso -o ubuntu.iso",
       "Save the first URL to a custom filename",
     )
-    .version("1.1.0")
+    .example(
+      "grab-url sftp://user@host/srv/backup.tar.gz --password hunter2",
+      "Pull a file over SFTP with aria2c",
+    )
+    .example(
+      'grab-url "magnet:?xt=urn:btih:HASH" -d ./downloads',
+      "Download a magnet link into ./downloads",
+    )
+    .example(
+      "grab-url https://example.com/big.iso --background",
+      "Detach immediately and keep downloading in the background",
+    )
+    .example("grab-url --jobs", "List background transfers that are still running")
+    .version("1.2.0")
     .strict()
     .parseSync();
 
@@ -95,21 +215,158 @@ if (__isMain) {
   const outputFile: string | null = argv.output;
   const noSave: boolean = argv["no-save"];
 
-  // Detect mode: download if any URL looks like a file, or multiple URLs provided
-  const anyFileUrl = urls.some(isFileUrl);
-  const isDownloadMode = urls.length > 1 || anyFileUrl;
+  // Path only — the state directory is created by whichever transfer needs it,
+  // so a plain API request leaves no .grab-downloads behind.
+  const stateDir = getStateDirectory();
+
+  let downloaderInstance: MultiColorFileDownloaderCLI | null = null;
+  /** Build the downloader on first use and wire up its Ctrl+C handler. */
+  const getDownloader = () => {
+    if (!downloaderInstance) {
+      downloaderInstance = new MultiColorFileDownloaderCLI();
+      downloaderInstance.setCancelHandler(handleCancel);
+    }
+    return downloaderInstance;
+  };
+
+  // --- Background job listing (no URL needed) ---
+  if (argv.jobs) {
+    printJobs(stateDir);
+    process.exit(0);
+  }
+
+  // --- Detach up front when --background was passed ---
+  if (argv.background && !isBackgroundChild()) {
+    const handoff = detachToBackground({
+      stateDir,
+      urls,
+      logFile: argv.log,
+      reason: "flag",
+    });
+    if (!handoff) process.exit(1);
+    reportDetached(handoff);
+    process.exit(0);
+  }
+
+  // Split targets: aria2c handles sftp / torrent / magnet, fetch() handles the rest
+  const aria2Targets = urls.filter(isAria2Target);
+  const webUrls = urls.filter((url) => !isAria2Target(url));
+  const anyFileUrl = webUrls.some(isFileUrl);
+  const isDownloadMode = webUrls.length > 1 || anyFileUrl;
+
+  const aria2Options = {
+    dir: argv.dir ? path.resolve(argv.dir) : process.cwd(),
+    output: outputFile,
+    seed: !!argv.seed,
+    connections: Number(argv.connections) || 8,
+    user: argv.user,
+    password: argv.password,
+    sshHostKey: argv["ssh-host-key"],
+    extraArgs:
+      typeof argv["aria2-args"] === "string"
+        ? argv["aria2-args"].split(" ").filter(Boolean)
+        : [],
+  };
+
+  // ── Cancellation: offer to keep the transfer running in the background ──────
+  let aria2Child: ChildProcess | null = null;
+  let cancelling = false;
+
+  /** Stop in-flight transfers so a background handoff can take over the files. */
+  const stopTransfers = async () => {
+    if (aria2Child && !aria2Child.killed) {
+      const child = aria2Child;
+      // SIGINT lets aria2c flush its .aria2 control file so the next run resumes.
+      const exited = new Promise<void>((resolve) => {
+        child.once("close", () => resolve());
+        setTimeout(resolve, 5000);
+      });
+      try {
+        child.kill("SIGCONT");
+        child.kill("SIGINT");
+      } catch {
+        /* already gone */
+      }
+      await exited;
+    }
+    downloaderInstance?.cleanup();
+    // Give the write streams a beat to flush before another process appends.
+    await new Promise((r) => setTimeout(r, 300));
+  };
+
+  const handleCancel = async () => {
+    if (cancelling) return;
+    cancelling = true;
+    // Silences the abort-induced "failed" reporting in the transfer engines.
+    setCancelInProgress(true);
+
+    const canPrompt = process.stdin.isTTY && !argv["no-bg-prompt"];
+    const keepGoing = canPrompt
+      ? await promptYesNo("🛑 Cancel — keep transferring in the background?", true)
+      : false;
+
+    await stopTransfers();
+
+    if (keepGoing) {
+      const handoff = detachToBackground({
+        stateDir,
+        urls,
+        logFile: argv.log,
+        reason: "cancel",
+      });
+      if (handoff) {
+        reportDetached(handoff);
+        process.exit(0);
+      }
+    }
+
+    console.log(colors.warning.bold("\n🛑 Transfer cancelled by user"));
+    console.log(
+      colors.info("💾 Partial progress saved. Run the same command to resume."),
+    );
+    process.exit(130);
+  };
+
+  if (!process.stdin.isTTY) process.on("SIGINT", () => void handleCancel());
 
   (async () => {
+    // --- aria2c Mode: sftp / torrent / magnet ---
+    let aria2Failures = 0;
+    for (const target of aria2Targets) {
+      const kind = classifyAria2Target(target)!;
+      const downloader = getDownloader();
+      downloader.setupGlobalKeyboardListener();
+      try {
+        await runAria2Transfer(target, aria2Options, {
+          isPaused: () => downloader.isPaused,
+          onChild: (child) => {
+            aria2Child = child;
+          },
+        });
+      } catch (error: any) {
+        if (isCancelInProgress()) return;
+        aria2Failures++;
+        console.error(
+          colors.error.bold(`💥 ${kind} transfer failed: `) +
+            colors.warning(error.message),
+        );
+      }
+    }
+    if (aria2Targets.length && !webUrls.length) {
+      downloaderInstance?.cleanup();
+      process.exit(aria2Failures > 0 ? 1 : 0);
+    }
+
     if (isDownloadMode) {
       // --- Download Mode ---
-      const downloader = new MultiColorFileDownloaderCLI();
-
-      const downloadObjects = urls.map((url, i) => {
+      const downloader = getDownloader();
+      const targetDir = argv.dir ? path.resolve(argv.dir) : process.cwd();
+      const downloadObjects = webUrls.map((url, i) => {
         let filename =
-          i === 0 && outputFile ? outputFile : downloader.generateFilename(url, process.cwd());
+          i === 0 && outputFile ? outputFile : downloader.generateFilename(url, targetDir);
         const outputPath = path.isAbsolute(filename)
           ? filename
-          : path.join(process.cwd(), filename);
+          : path.join(targetDir, filename);
         const outputDir = path.dirname(outputPath);
         try {
           if (!fs.existsSync(outputDir))
@@ -126,6 +383,7 @@ if (__isMain) {
 
       try {
         await downloader.downloadMultipleFiles(downloadObjects);
+        if (isCancelInProgress()) return;
 
         // Display file stats table
         const statsTable = new Table({
@@ -156,6 +414,7 @@ if (__isMain) {
         console.log(chalk.cyan.bold("\nFile Details:"));
         console.log(statsTable.toString());
       } catch (error: any) {
+        if (isCancelInProgress()) return;
         console.error(
           chalk.red.bold("Failed to download files: ") +
             chalk.yellow(error.message),
@@ -165,7 +424,7 @@ if (__isMain) {
       downloader.cleanup();
     } else {
       // --- API Mode ---
-      const url = urls[0];
+      const url = webUrls[0];
       const startTime = process.hrtime();
 
       try {

--- a/packages/grab-url-cli/src/keyboard-controls.ts
+++ b/packages/grab-url-cli/src/keyboard-controls.ts
@@ -19,18 +19,37 @@ export interface KeyboardCallbacks {
     hasMultiBar: () => boolean;
     addToMultipleDownloads: (url: string, outputPath: string, filename: string) => Promise<void>;
     downloadFile: (url: string, outputPath: string) => Promise<void>;
+    /**
+     * Called on Ctrl+C instead of exiting outright — the CLI uses it to offer
+     * handing the transfer off to a background process. It is expected to end
+     * the process itself.
+     */
+    onCancel?: () => Promise<void> | void;
 }
+
+/**
+ * True while a nested prompt (cancel confirmation) owns stdin, so the main
+ * listener stops interpreting keystrokes as download controls.
+ */
+let promptActive = false;
 
 // ─── Keyboard listener ────────────────────────────────────────────────────────
 
+/** Tracks whether this module already attached its stdin listener. */
+let listenerAttached = false;
+
 /**
  * Attach a raw-mode stdin listener.
- * - Ctrl+C → exit
+ * - Ctrl+C → run `onCancel` (offer a background handoff) or exit
  * - p      → toggle pause/resume
  * - a      → prompt to add a URL
+ *
+ * Calling this more than once is a no-op, so several transfers can share one
+ * listener.
  */
 export function setupKeyboardListener(callbacks: KeyboardCallbacks): void {
-    if (!process.stdin.isTTY) return;
+    if (!process.stdin.isTTY || listenerAttached) return;
+    listenerAttached = true;
 
     process.stdin.setRawMode(true);
     process.stdin.resume();
@@ -38,9 +57,17 @@ export function setupKeyboardListener(callbacks: KeyboardCallbacks): void {
 
     process.stdin.on('data', async (str: string) => {
         if (str === '\u0003') {
+            // A confirmation prompt owns stdin — let it consume this keystroke.
+            if (promptActive) return;
+            if (callbacks.onCancel) {
+                promptActive = true;
+                try { await callbacks.onCancel(); } finally { promptActive = false; }
+                return;
+            }
             console.log(colors.warning.bold('\n🛑 Downloads cancelled by user'));
             process.exit(0);
         }
+        if (promptActive) return;
         if (str.toLowerCase() === 'p') {
             if (!callbacks.isPaused()) callbacks.pauseAll();
             else callbacks.resumeAll();
@@ -59,6 +86,7 @@ export function teardownKeyboardListener(): void {
         process.stdin.setRawMode(false);
         process.stdin.pause();
     }
+    listenerAttached = false;
 }
 
 // ─── URL prompt ───────────────────────────────────────────────────────────────

--- a/packages/grab-url-cli/src/transfer/aria2-transfer.ts
+++ b/packages/grab-url-cli/src/transfer/aria2-transfer.ts
@@ -1,0 +1,508 @@
+/**
+ * @file aria2-transfer.ts
+ * @description SFTP, BitTorrent (.torrent) and magnet-URI transfers delegated to
+ * the external `aria2c` binary, wrapped in the same cli-progress UI the HTTP
+ * downloader uses.
+ *
+ * `fetch()` cannot speak SFTP or BitTorrent, so those targets are handed to
+ * aria2c, whose console readout is parsed line-by-line and mirrored into a
+ * progress bar. Everything here is pure except `runAria2Transfer`, which spawns
+ * the child process.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { spawn, spawnSync, type ChildProcess } from 'child_process';
+
+import cliProgress from 'cli-progress';
+
+import {
+    COL_BAR, COL_FILENAME,
+    colors,
+    formatBytes, formatBytesCompact, formatETA, formatProgress,
+    formatSpeed, formatSpeedDisplay, formatTotalDisplay, truncateFilename,
+} from '../display/progress-format.js';
+
+import {
+    getSpinnerFrames, getRandomSpinner, getSpinnerWidth,
+    calculateBarSize, getRandomBarColor, getRandomBarGlueColor,
+} from '../display/spinner-config.js';
+
+import { isCancelInProgress } from '../cancel-state.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Transfer kinds that are delegated to aria2c rather than fetch(). */
+export type Aria2Kind = 'sftp' | 'magnet' | 'torrent';
+
+export interface Aria2Options {
+    /** Destination directory (aria2 `--dir`). Defaults to cwd. */
+    dir?: string;
+    /** Explicit output filename — ignored for torrents/magnets (they carry names). */
+    output?: string | null;
+    /** Keep seeding after a torrent completes (default: stop immediately). */
+    seed?: boolean;
+    /** Connections per server / split count for sftp transfers. */
+    connections?: number;
+    /** Username for sftp (or use the URI's userinfo). */
+    user?: string | null;
+    /** Password for sftp. */
+    password?: string | null;
+    /** Expected sftp host key digest, e.g. `sha-1=b030503...`. */
+    sshHostKey?: string | null;
+    /** Raw extra flags appended verbatim to the aria2c invocation. */
+    extraArgs?: string[];
+}
+
+export interface Aria2Context {
+    /** Live pause state — polled so `p` suspends/resumes the child. */
+    isPaused: () => boolean;
+    /** Receives the spawned child so callers can cancel it. */
+    onChild?: (child: ChildProcess | null) => void;
+}
+
+export interface Aria2Progress {
+    gid: string;
+    downloaded: number;
+    total: number;
+    percent: number;
+    speedBps: number;
+    uploadBps: number;
+    connections: number;
+    seeders: number | null;
+    etaSeconds: number;
+    /** True once a torrent finished downloading and is only seeding. */
+    seeding: boolean;
+}
+
+// ─── Target detection ─────────────────────────────────────────────────────────
+
+/**
+ * Classify a target as an aria2-handled transfer, or null when the plain
+ * fetch()-based downloader applies.
+ *
+ * @param target - URL, magnet URI, or path to a `.torrent` file
+ */
+export function classifyAria2Target(target: string): Aria2Kind | null {
+    if (!target) return null;
+    const value = target.trim();
+    if (/^magnet:\?/i.test(value)) return 'magnet';
+    if (/^sftp:\/\//i.test(value)) return 'sftp';
+    if (/\.torrent$/i.test(value.split('?')[0].split('#')[0])) return 'torrent';
+    return null;
+}
+
+/** True when a target must go through aria2c instead of fetch(). */
+export function isAria2Target(target: string): boolean {
+    return classifyAria2Target(target) !== null;
+}
+
+/** Human-readable label for a target, used for the progress bar and logs. */
+export function describeAria2Target(target: string, kind: Aria2Kind): string {
+    if (kind === 'magnet') {
+        const dn = /[?&]dn=([^&]+)/i.exec(target);
+        if (dn) {
+            try { return decodeURIComponent(dn[1].replace(/\+/g, ' ')); } catch { return dn[1]; }
+        }
+        const xt = /xt=urn:btih:([a-z0-9]+)/i.exec(target);
+        return xt ? `magnet ${xt[1].slice(0, 12)}` : 'magnet link';
+    }
+    if (kind === 'torrent') return path.basename(target.split('?')[0]);
+    try { return path.basename(new URL(target).pathname) || target; } catch { return target; }
+}
+
+// ─── Binary discovery ─────────────────────────────────────────────────────────
+
+/**
+ * Locate a usable `aria2c` binary (honouring `GRAB_ARIA2_PATH`) and return its
+ * path, reported version and compiled-in features, or null when it is not
+ * installed.
+ */
+export function findAria2(): { path: string; version: string; features: string[] } | null {
+    const candidate = process.env.GRAB_ARIA2_PATH || 'aria2c';
+    try {
+        const probe = spawnSync(candidate, ['--version'], { encoding: 'utf8' });
+        if (probe.error || probe.status !== 0) return null;
+        const stdout = probe.stdout || '';
+        const version = /aria2 version ([\d.]+)/i.exec(stdout)?.[1] ?? 'unknown';
+        return { path: candidate, version, features: parseAria2Features(stdout) };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Read the "Enabled Features" line of `aria2c --version`. SFTP and BitTorrent
+ * are compile-time options, so a working binary may still not speak them.
+ */
+export function parseAria2Features(versionOutput: string): string[] {
+    const line = /Enabled Features:(.*)/i.exec(versionOutput || '')?.[1];
+    if (!line) return [];
+    return line.split(',').map((f) => f.trim()).filter(Boolean);
+}
+
+/** True when the binary was built with support for a given transfer kind. */
+export function supportsKind(features: string[], kind: Aria2Kind): boolean {
+    if (!features.length) return true; // unknown build — let aria2c decide
+    const needed = kind === 'sftp' ? 'sftp' : 'bittorrent';
+    return features.some((f) => f.toLowerCase() === needed);
+}
+
+/**
+ * Hide the password in a `scheme://user:password@host` URI before it reaches a
+ * console or a log file.
+ */
+export function redactCredentials(text: string): string {
+    return text.replace(/(\w+:\/\/[^/\s:@]+):[^/\s@]*@/g, '$1:***@');
+}
+
+/** Platform-appropriate install hint shown when aria2c is missing. */
+export function aria2InstallHint(): string {
+    const hints: Record<string, string> = {
+        darwin: 'brew install aria2',
+        linux: 'sudo apt install aria2   (or dnf/pacman/apk install aria2)',
+        win32: 'winget install aria2.aria2   (or choco install aria2)',
+    };
+    return hints[process.platform] ?? 'https://aria2.github.io/';
+}
+
+// ─── Argument building ────────────────────────────────────────────────────────
+
+/**
+ * Build the full aria2c argument list for a target. Pure — no side effects — so
+ * the flag matrix stays unit-testable.
+ *
+ * @param target - URL, magnet URI or `.torrent` path
+ * @param kind   - Result of {@link classifyAria2Target}
+ * @param opts   - User-supplied transfer options
+ */
+export function buildAria2Args(target: string, kind: Aria2Kind, opts: Aria2Options = {}): string[] {
+    const connections = Math.min(Math.max(opts.connections ?? 8, 1), 16);
+    const args = [
+        '--summary-interval=1',
+        '--console-log-level=warn',
+        '--human-readable=false',
+        '--download-result=full',
+        '--continue=true',
+        '--auto-file-renaming=false',
+        '--file-allocation=none',
+        `--dir=${opts.dir || process.cwd()}`,
+    ];
+
+    if (kind === 'sftp') {
+        args.push(
+            `--max-connection-per-server=${connections}`,
+            `--split=${connections}`,
+        );
+        if (opts.user) args.push(`--ftp-user=${opts.user}`);
+        if (opts.password) args.push(`--ftp-passwd=${opts.password}`);
+        if (opts.sshHostKey) args.push(`--ssh-host-key-md=${opts.sshHostKey}`);
+        if (opts.output) args.push(`--out=${path.basename(opts.output)}`);
+    } else {
+        // Torrent + magnet: aria2 takes the file names from the metadata.
+        args.push('--follow-torrent=true', '--bt-save-metadata=true');
+        if (opts.seed) args.push('--seed-ratio=0.0');
+        else args.push('--seed-time=0');
+    }
+
+    if (opts.extraArgs?.length) args.push(...opts.extraArgs);
+    args.push(target);
+    return args;
+}
+
+// ─── Console-readout parsing ──────────────────────────────────────────────────
+
+const UNIT_FACTORS: Record<string, number> = {
+    '': 1, B: 1,
+    K: 1024, KI: 1024, KIB: 1024, KB: 1024,
+    M: 1024 ** 2, MI: 1024 ** 2, MIB: 1024 ** 2, MB: 1024 ** 2,
+    G: 1024 ** 3, GI: 1024 ** 3, GIB: 1024 ** 3, GB: 1024 ** 3,
+    T: 1024 ** 4, TI: 1024 ** 4, TIB: 1024 ** 4, TB: 1024 ** 4,
+};
+
+/**
+ * Convert an aria2 size token (`4096`, `400KiB`, `1.4GiB`) into bytes.
+ */
+export function parseAria2Size(token: string | undefined | null): number {
+    if (!token) return 0;
+    const match = /^([\d.]+)\s*([KMGT]i?B?|B)?$/i.exec(token.trim());
+    if (!match) return 0;
+    const factor = UNIT_FACTORS[(match[2] ?? '').toUpperCase()] ?? 1;
+    return Math.round(parseFloat(match[1]) * factor);
+}
+
+/**
+ * Convert an aria2 ETA token (`45s`, `4m51s`, `1h2m3s`, `2d3h`) into seconds.
+ */
+export function parseAria2Eta(token: string | undefined | null): number {
+    if (!token) return 0;
+    let seconds = 0;
+    const re = /(\d+)([dhms])/gi;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(token))) {
+        const n = parseInt(match[1], 10);
+        const unit = match[2].toLowerCase();
+        seconds += unit === 'd' ? n * 86400 : unit === 'h' ? n * 3600 : unit === 'm' ? n * 60 : n;
+    }
+    return seconds;
+}
+
+/**
+ * Parse one aria2c console-readout line into structured progress.
+ * Returns null for lines that carry no download stats (log messages, banners).
+ *
+ * Handles the human-readable readout (`400KiB/33MiB(1%)`), the raw-byte readout
+ * produced by `--human-readable=false`, and the seeding form (`SEED(1.0) SD:2`).
+ */
+export function parseAria2Progress(line: string): Aria2Progress | null {
+    const group = /\[#([0-9a-zA-Z]+)\s([^\]]*)\]/.exec(line);
+    if (!group) return null;
+    const [, gid, body] = group;
+
+    const sizes = /([\d.]+(?:[KMGT]i?B?|B)?)\/([\d.]+(?:[KMGT]i?B?|B)?)\((\d+)%\)/.exec(body);
+    const seed = /SEED\(([\d.]+)\)/.exec(body);
+    if (!sizes && !seed) return null;
+
+    const seeders = /SD:(\d+)/.exec(body);
+    return {
+        gid,
+        downloaded: sizes ? parseAria2Size(sizes[1]) : 0,
+        total: sizes ? parseAria2Size(sizes[2]) : 0,
+        percent: sizes ? parseInt(sizes[3], 10) : 100,
+        speedBps: parseAria2Size(/DL:([\d.]+(?:[KMGT]i?B?|B)?)/.exec(body)?.[1]),
+        uploadBps: parseAria2Size(/UL:([\d.]+(?:[KMGT]i?B?|B)?)/.exec(body)?.[1]),
+        connections: parseInt(/CN:(\d+)/.exec(body)?.[1] ?? '0', 10),
+        seeders: seeders ? parseInt(seeders[1], 10) : null,
+        etaSeconds: parseAria2Eta(/ETA:([\dhdms]+)/i.exec(body)?.[1]),
+        seeding: !!seed,
+    };
+}
+
+/**
+ * True for aria2's banner, results header and legend lines — they carry no
+ * information about why a transfer failed.
+ */
+export function isAria2Noise(line: string): boolean {
+    return /^(gid\s|===|---|\*\*\*|FILE:|Download Results:|Status Legend:|\(OK\)|\(ERR\)|\(INPR\)|aria2 will resume|If there are any errors)/i
+        .test(line.trim());
+}
+
+/** Map an aria2c exit code to a readable reason. */
+export function describeAria2Exit(code: number | null): string {
+    const reasons: Record<number, string> = {
+        0: 'completed',
+        1: 'unknown error',
+        2: 'timed out',
+        3: 'resource not found',
+        4: 'resource not found too many times',
+        5: 'download aborted because it was too slow',
+        6: 'network problem',
+        7: 'stopped with unfinished downloads',
+        8: 'server does not support resume',
+        9: 'not enough disk space',
+        11: 'aria2 was already downloading the same file',
+        12: 'aria2 was already downloading the same torrent',
+        13: 'file already exists — remove it or pass --dir',
+        16: 'could not open the destination file',
+        22: 'bad HTTP response header',
+        24: 'authorization failed',
+        25: 'could not parse the torrent/metalink file',
+        28: 'bad command-line option',
+        29: 'server temporarily unavailable',
+    };
+    if (code === null) return 'terminated by signal';
+    return reasons[code] ?? `exit code ${code}`;
+}
+
+// ─── Transfer ─────────────────────────────────────────────────────────────────
+
+/**
+ * Run one aria2c transfer with a live progress bar.
+ *
+ * Pause (`p`) suspends the child with SIGSTOP/SIGCONT on POSIX; cancellation is
+ * delivered as SIGINT so aria2 flushes its `.aria2` control file and the next
+ * run resumes where this one stopped.
+ *
+ * @param target - URL, magnet URI or `.torrent` path
+ * @param opts   - Transfer options
+ * @param ctx    - Pause state plus child-process handle callback
+ */
+export async function runAria2Transfer(
+    target: string,
+    opts: Aria2Options = {},
+    ctx: Aria2Context = { isPaused: () => false },
+): Promise<void> {
+    const kind = classifyAria2Target(target);
+    if (!kind) throw new Error(`Not an aria2 target: ${target}`);
+
+    const aria2 = findAria2();
+    if (!aria2) {
+        throw new Error(
+            `aria2c is required for ${kind} transfers but was not found. ` +
+            `Install it with: ${aria2InstallHint()}`,
+        );
+    }
+
+    if (!supportsKind(aria2.features, kind)) {
+        throw new Error(
+            `this aria2c build has no ${kind === 'sftp' ? 'SFTP' : 'BitTorrent'} support ` +
+            `(features: ${aria2.features.join(', ') || 'unknown'}). Install a build with it, ` +
+            `or point GRAB_ARIA2_PATH at one.`,
+        );
+    }
+
+    const dir = opts.dir || process.cwd();
+    try {
+        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    } catch (e: any) {
+        throw new Error(`Could not create output directory ${dir}: ${e.message}`);
+    }
+
+    const label = describeAria2Target(target, kind);
+    const icons: Record<Aria2Kind, string> = { sftp: '🔐', magnet: '🧲', torrent: '🌊' };
+    console.log(colors.info(`${icons[kind]} ${kind} via aria2c ${aria2.version}: ${label}`));
+
+    const args = buildAria2Args(target, kind, { ...opts, dir });
+    const frames = getSpinnerFrames(getRandomSpinner());
+    const barColor = getRandomBarColor();
+    const barGlue = getRandomBarGlueColor();
+    const spinnerWidth = getSpinnerWidth(frames[0]);
+    const RESET = '\u001b[0m';
+
+    const bar = new cliProgress.SingleBar({
+        format:
+            colors.success('{percentage}%') + ' ' +
+            colors.yellow('{filename}') + ' ' +
+            colors.cyan('{spinner}') + ' ' +
+            barColor + '{bar}' + RESET + ' ' +
+            colors.info('{downloadedDisplay}') + ' ' + colors.info('{totalDisplay}') + ' ' +
+            colors.purple('{speed}') + ' ' + colors.pink('{etaFormatted}') + ' ' +
+            colors.primary('{peers}'),
+        barCompleteChar: '█',
+        barIncompleteChar: '░',
+        barGlue,
+        hideCursor: true,
+        barsize: calculateBarSize(frames[0], COL_BAR),
+        clearOnComplete: false,
+        stopOnComplete: false,
+    });
+
+    bar.start(100, 0, {
+        filename: truncateFilename(label, COL_FILENAME - spinnerWidth),
+        spinner: frames[0],
+        speed: formatSpeed('0B'),
+        etaFormatted: formatETA(0),
+        progress: formatProgress(0, 0),
+        downloadedDisplay: formatBytesCompact(0),
+        totalDisplay: formatTotalDisplay(0),
+        peers: '',
+    });
+
+    const child = spawn(aria2.path, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    ctx.onChild?.(child);
+
+    let frameIndex = 0;
+    let lastFrame = Date.now();
+    let knownTotal = 0;
+    let lastDownloaded = 0;
+    let suspended = false;
+    const messages: string[] = [];
+    const resultLines: string[] = [];
+
+    const pausePoll = setInterval(() => {
+        if (process.platform === 'win32' || child.killed) return;
+        const wantPaused = ctx.isPaused();
+        if (wantPaused && !suspended) {
+            try { child.kill('SIGSTOP'); suspended = true; } catch { /* already gone */ }
+        } else if (!wantPaused && suspended) {
+            try { child.kill('SIGCONT'); suspended = false; } catch { /* already gone */ }
+        }
+    }, 200);
+
+    const handleLine = (line: string) => {
+        const text = line.trim();
+        if (!text) return;
+
+        const progress = parseAria2Progress(text);
+        if (progress) {
+            if (progress.total > 0 && progress.total !== knownTotal) {
+                knownTotal = progress.total;
+                bar.setTotal(knownTotal);
+            }
+            const now = Date.now();
+            if (now - lastFrame >= 120) {
+                frameIndex = (frameIndex + 1) % frames.length;
+                lastFrame = now;
+                bar.options.barsize = calculateBarSize(frames[frameIndex], COL_BAR);
+            }
+            lastDownloaded = progress.downloaded || lastDownloaded;
+
+            bar.update(knownTotal > 0 ? progress.downloaded : progress.percent, {
+                spinner: progress.seeding ? '🌱' : frames[frameIndex],
+                speed: formatSpeed(formatSpeedDisplay(progress.speedBps)),
+                etaFormatted: formatETA(progress.etaSeconds),
+                progress: formatProgress(progress.downloaded, knownTotal),
+                downloadedDisplay: formatBytesCompact(progress.downloaded),
+                totalDisplay: formatTotalDisplay(knownTotal),
+                peers: progress.seeders !== null
+                    ? `CN:${progress.connections} SD:${progress.seeders}`
+                    : `CN:${progress.connections}`,
+            });
+            return;
+        }
+
+        // Non-progress output: keep the download results and a tail of messages.
+        if (/^[0-9a-f]{6}\|/i.test(text)) { resultLines.push(text); return; }
+        if (isAria2Noise(text)) return;
+        messages.push(redactCredentials(text));
+        if (messages.length > 10) messages.shift();
+    };
+
+    const attach = (stream: NodeJS.ReadableStream | null) => {
+        if (!stream) return;
+        let buffer = '';
+        stream.setEncoding('utf8');
+        stream.on('data', (chunk: string) => {
+            buffer += chunk;
+            // aria2 redraws its readout with \r, so split on both terminators.
+            const parts = buffer.split(/\r|\n/);
+            buffer = parts.pop() ?? '';
+            parts.forEach(handleLine);
+        });
+        stream.on('end', () => { if (buffer) handleLine(buffer); });
+    };
+    attach(child.stdout);
+    attach(child.stderr);
+
+    const exitCode: number | null = await new Promise((resolve, reject) => {
+        child.on('error', reject);
+        child.on('close', (code) => resolve(code));
+    });
+
+    clearInterval(pausePoll);
+    bar.stop();
+    ctx.onChild?.(null);
+
+    if (exitCode === 0) {
+        const saved = resultLines
+            .map((line) => line.split('|').pop()?.trim())
+            .filter((p): p is string => !!p && p !== 'path/URI');
+        console.log(colors.success('✅ Transfer completed!'));
+        if (saved.length)
+            console.log(colors.primary('📁 Saved to: ') + redactCredentials(saved.join(', ')));
+        if (lastDownloaded > 0) console.log(colors.purple('📊 Total: ') + formatBytes(lastDownloaded));
+        return;
+    }
+
+    // The user asked to stop — the CLI reports the outcome, not aria2's teardown.
+    if (isCancelInProgress()) throw new Error(`aria2c ${describeAria2Exit(exitCode)}`);
+
+    // Prefer the lines that name the cause over aria2's generic footer.
+    const causes = messages.filter((m) => /error|exception|->|denied|refused/i.test(m));
+    (causes.length ? causes : messages).slice(-5)
+        .forEach((m) => console.log(colors.warning(`   ${m}`)));
+    if (exitCode === 7 || exitCode === null) {
+        console.log(colors.info('💾 Progress saved by aria2c. Run the same command to resume.'));
+    }
+    throw new Error(`aria2c ${describeAria2Exit(exitCode)}`);
+}

--- a/packages/grab-url-cli/src/transfer/multi-file-transfer.ts
+++ b/packages/grab-url-cli/src/transfer/multi-file-transfer.ts
@@ -30,6 +30,8 @@ import {
     getRandomBarColor, getRandomBarGlueColor,
 } from '../display/spinner-config.js';
 
+import { isCancelInProgress } from '../cancel-state.js';
+
 import {
     checkServerSupport, resolveResumeDecision,
     loadDownloadState, saveDownloadState,
@@ -215,6 +217,9 @@ export async function downloadMultipleFiles(
         clearInterval(speedInterval);
         ctx.multiBar.stop();
 
+        // A cancellation aborts every request; the handoff message reports it.
+        if (isCancelInProgress()) return;
+
         const ok = results.filter((r: any) => r.status === 'fulfilled' && r.value.success).length;
         const fail = results.length - ok;
         if (fail > 0) {
@@ -356,6 +361,7 @@ export async function downloadSingleFileWithBar(
         });
 
     } catch (e: any) {
+        if (isCancelInProgress()) throw e;
         bar.update(bar.total, {
             spinner: '❌', speed: formatSpeed('FAILED'),
             downloadedDisplay: formatBytesCompact(0), totalDisplay: formatTotalDisplay(0),

--- a/packages/grab-url-cli/src/transfer/single-file-transfer.ts
+++ b/packages/grab-url-cli/src/transfer/single-file-transfer.ts
@@ -31,6 +31,8 @@ import {
   getRandomBarGlueColor,
 } from "../display/spinner-config.js";
 
+import { isCancelInProgress } from "../cancel-state.js";
+
 import {
   checkServerSupport,
   resolveResumeDecision,
@@ -288,6 +290,7 @@ export async function downloadFile(
     );
   } catch (e: any) {
     if (ctx.progressBar) ctx.progressBar.stop();
+    if (isCancelInProgress()) throw e;
     console.error(
       colors.error.bold("💥 Download failed: ") + colors.warning(e.message),
     );

--- a/test/aria2.test.ts
+++ b/test/aria2.test.ts
@@ -1,0 +1,356 @@
+/**
+ * @file aria2.test.ts
+ * @description Unit tests for the aria2c-backed transfer layer (sftp, torrent,
+ * magnet) and for background-job handling:
+ *   - transfer/aria2-transfer.ts  (target detection, arg building, readout parsing)
+ *   - background.ts               (argv rewriting, job registry, log paths)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import {
+    classifyAria2Target,
+    isAria2Target,
+    describeAria2Target,
+    buildAria2Args,
+    parseAria2Size,
+    parseAria2Eta,
+    parseAria2Progress,
+    describeAria2Exit,
+    aria2InstallHint,
+    parseAria2Features,
+    supportsKind,
+    redactCredentials,
+    isAria2Noise,
+} from '../packages/grab-url-cli/src/transfer/aria2-transfer.js';
+
+import {
+    BACKGROUND_CHILD_FLAG,
+    buildChildArgv,
+    isBackgroundChild,
+    buildLogPath,
+    getJobsDirectory,
+    getLogsDirectory,
+    writeJobRecord,
+    listJobs,
+    isProcessAlive,
+} from '../packages/grab-url-cli/src/background.js';
+
+// ─── Target detection ─────────────────────────────────────────────────────────
+
+describe('aria2 — classifyAria2Target()', () => {
+    it('detects magnet URIs', () => {
+        expect(classifyAria2Target('magnet:?xt=urn:btih:abc123&dn=ubuntu.iso')).toBe('magnet');
+    });
+    it('detects sftp URLs', () => {
+        expect(classifyAria2Target('sftp://user@host/srv/backup.tar.gz')).toBe('sftp');
+    });
+    it('detects remote .torrent files', () => {
+        expect(classifyAria2Target('https://example.com/ubuntu.torrent')).toBe('torrent');
+    });
+    it('detects local .torrent paths', () => {
+        expect(classifyAria2Target('./downloads/ubuntu.torrent')).toBe('torrent');
+    });
+    it('ignores the query string when matching .torrent', () => {
+        expect(classifyAria2Target('https://example.com/x.torrent?token=1')).toBe('torrent');
+    });
+    it('returns null for plain http(s) URLs', () => {
+        expect(classifyAria2Target('https://example.com/file.iso')).toBeNull();
+    });
+    it('returns null for empty input', () => {
+        expect(classifyAria2Target('')).toBeNull();
+    });
+    it('isAria2Target mirrors classifyAria2Target', () => {
+        expect(isAria2Target('sftp://host/f.bin')).toBe(true);
+        expect(isAria2Target('https://host/f.bin')).toBe(false);
+    });
+});
+
+describe('aria2 — describeAria2Target()', () => {
+    it('uses the magnet display-name when present', () => {
+        expect(describeAria2Target('magnet:?xt=urn:btih:abc&dn=ubuntu+24.04.iso', 'magnet'))
+            .toBe('ubuntu 24.04.iso');
+    });
+    it('falls back to the info hash for nameless magnets', () => {
+        expect(describeAria2Target('magnet:?xt=urn:btih:abcdef0123456789', 'magnet'))
+            .toContain('abcdef012345');
+    });
+    it('uses the basename for torrents', () => {
+        expect(describeAria2Target('https://example.com/a/ubuntu.torrent', 'torrent')).toBe('ubuntu.torrent');
+    });
+    it('uses the basename for sftp paths', () => {
+        expect(describeAria2Target('sftp://user@host/srv/backup.tar.gz', 'sftp')).toBe('backup.tar.gz');
+    });
+});
+
+// ─── Argument building ────────────────────────────────────────────────────────
+
+describe('aria2 — buildAria2Args()', () => {
+    it('always requests a parsable readout and resume', () => {
+        const args = buildAria2Args('sftp://host/f.bin', 'sftp', { dir: '/tmp' });
+        expect(args).toContain('--summary-interval=1');
+        expect(args).toContain('--human-readable=false');
+        expect(args).toContain('--continue=true');
+        expect(args).toContain('--dir=/tmp');
+    });
+    it('puts the target last', () => {
+        const args = buildAria2Args('sftp://host/f.bin', 'sftp', {});
+        expect(args[args.length - 1]).toBe('sftp://host/f.bin');
+    });
+    it('passes sftp credentials and host key', () => {
+        const args = buildAria2Args('sftp://host/f.bin', 'sftp', {
+            user: 'alice', password: 'hunter2', sshHostKey: 'sha-1=abc',
+        });
+        expect(args).toContain('--ftp-user=alice');
+        expect(args).toContain('--ftp-passwd=hunter2');
+        expect(args).toContain('--ssh-host-key-md=sha-1=abc');
+    });
+    it('clamps the connection count to 1..16', () => {
+        expect(buildAria2Args('sftp://h/f', 'sftp', { connections: 99 })).toContain('--split=16');
+        expect(buildAria2Args('sftp://h/f', 'sftp', { connections: 0 })).toContain('--split=1');
+    });
+    it('renames sftp output with --out when -o is given', () => {
+        const args = buildAria2Args('sftp://host/f.bin', 'sftp', { output: '/downloads/renamed.bin' });
+        expect(args).toContain('--out=renamed.bin');
+    });
+    it('stops seeding torrents by default', () => {
+        const args = buildAria2Args('x.torrent', 'torrent', {});
+        expect(args).toContain('--seed-time=0');
+        expect(args).not.toContain('--seed-ratio=0.0');
+    });
+    it('keeps seeding when --seed is set', () => {
+        const args = buildAria2Args('x.torrent', 'torrent', { seed: true });
+        expect(args).toContain('--seed-ratio=0.0');
+        expect(args).not.toContain('--seed-time=0');
+    });
+    it('saves metadata for magnet links', () => {
+        const args = buildAria2Args('magnet:?xt=urn:btih:abc', 'magnet', {});
+        expect(args).toContain('--bt-save-metadata=true');
+        expect(args).toContain('--follow-torrent=true');
+    });
+    it('never sends sftp-only flags for torrents', () => {
+        const args = buildAria2Args('x.torrent', 'torrent', { user: 'alice' });
+        expect(args.some(a => a.startsWith('--ftp-user'))).toBe(false);
+    });
+    it('appends extra aria2 flags verbatim before the target', () => {
+        const args = buildAria2Args('x.torrent', 'torrent', { extraArgs: ['--max-overall-download-limit=1M'] });
+        expect(args[args.length - 2]).toBe('--max-overall-download-limit=1M');
+    });
+});
+
+// ─── Readout parsing ──────────────────────────────────────────────────────────
+
+describe('aria2 — parseAria2Size()', () => {
+    it('reads raw byte counts', () => expect(parseAria2Size('4096')).toBe(4096));
+    it('reads KiB', () => expect(parseAria2Size('400KiB')).toBe(409600));
+    it('reads MiB with decimals', () => expect(parseAria2Size('33.2MiB')).toBe(Math.round(33.2 * 1024 ** 2)));
+    it('reads GiB', () => expect(parseAria2Size('1.4GiB')).toBe(Math.round(1.4 * 1024 ** 3)));
+    it('returns 0 for missing or junk input', () => {
+        expect(parseAria2Size(undefined)).toBe(0);
+        expect(parseAria2Size('n/a')).toBe(0);
+    });
+});
+
+describe('aria2 — parseAria2Eta()', () => {
+    it('reads seconds', () => expect(parseAria2Eta('45s')).toBe(45));
+    it('reads minutes and seconds', () => expect(parseAria2Eta('4m51s')).toBe(291));
+    it('reads hours', () => expect(parseAria2Eta('1h2m3s')).toBe(3723));
+    it('reads days', () => expect(parseAria2Eta('2d3h')).toBe(2 * 86400 + 3 * 3600));
+    it('returns 0 for missing input', () => expect(parseAria2Eta(null)).toBe(0));
+});
+
+describe('aria2 — parseAria2Progress()', () => {
+    it('parses a human-readable http/sftp readout', () => {
+        const p = parseAria2Progress('[#2089b0 400KiB/33.2MiB(1%) CN:1 DL:115KiB ETA:4m51s]')!;
+        expect(p.gid).toBe('2089b0');
+        expect(p.downloaded).toBe(409600);
+        expect(p.percent).toBe(1);
+        expect(p.speedBps).toBe(115 * 1024);
+        expect(p.etaSeconds).toBe(291);
+        expect(p.connections).toBe(1);
+        expect(p.seeders).toBeNull();
+        expect(p.seeding).toBe(false);
+    });
+    it('parses the byte-suffixed readout aria2 1.37 emits with --human-readable=false', () => {
+        const p = parseAria2Progress('[#fa63e7 409600B/3145728B(13%) CN:1 SD:0 DL:208990B ETA:13s]')!;
+        expect(p.downloaded).toBe(409600);
+        expect(p.total).toBe(3145728);
+        expect(p.speedBps).toBe(208990);
+        expect(p.seeders).toBe(0);
+        expect(p.etaSeconds).toBe(13);
+    });
+    it('parses the raw-byte readout produced by --human-readable=false', () => {
+        const p = parseAria2Progress('[#a1b2c3 409600/34865152(1%) CN:5 DL:118477 ETA:4m]')!;
+        expect(p.downloaded).toBe(409600);
+        expect(p.total).toBe(34865152);
+        expect(p.speedBps).toBe(118477);
+        expect(p.etaSeconds).toBe(240);
+    });
+    it('parses torrent readouts with seeders and upload', () => {
+        const p = parseAria2Progress('[#7d3d4e 12MiB/1.4GiB(0%) CN:34 SD:5 DL:2.4MiB UL:512KiB ETA:9m]')!;
+        expect(p.seeders).toBe(5);
+        expect(p.connections).toBe(34);
+        expect(p.uploadBps).toBe(512 * 1024);
+    });
+    it('flags the seeding phase', () => {
+        const p = parseAria2Progress('[#2089b0 SEED(1.0) CN:1 SD:2]')!;
+        expect(p.seeding).toBe(true);
+        expect(p.percent).toBe(100);
+        expect(p.seeders).toBe(2);
+    });
+    it('returns null for log lines', () => {
+        expect(parseAria2Progress('09/09 04:11:22 [NOTICE] Downloading 1 item(s)')).toBeNull();
+        expect(parseAria2Progress('')).toBeNull();
+    });
+    it('returns null for bracketed lines without stats', () => {
+        expect(parseAria2Progress('[MEMORY] CUID#7 - Dumping memory')).toBeNull();
+    });
+});
+
+describe('aria2 — describeAria2Exit()', () => {
+    it('names known exit codes', () => {
+        expect(describeAria2Exit(0)).toBe('completed');
+        expect(describeAria2Exit(3)).toContain('not found');
+        expect(describeAria2Exit(9)).toContain('disk space');
+    });
+    it('falls back to the raw code', () => expect(describeAria2Exit(99)).toContain('99'));
+    it('reports signal termination', () => expect(describeAria2Exit(null)).toContain('signal'));
+    it('always offers an install hint', () => expect(aria2InstallHint().length).toBeGreaterThan(0));
+});
+
+describe('aria2 — build capabilities', () => {
+    const versionOutput = [
+        'aria2 version 1.37.0',
+        'Enabled Features: Async DNS, BitTorrent, GZip, HTTPS, Metalink, XML-RPC, SFTP',
+        'Libraries: zlib/1.3 libssh2/1.11.0',
+    ].join('\n');
+
+    it('reads the enabled feature list', () => {
+        expect(parseAria2Features(versionOutput)).toContain('SFTP');
+        expect(parseAria2Features(versionOutput)).toContain('BitTorrent');
+    });
+    it('returns an empty list when the line is absent', () => {
+        expect(parseAria2Features('aria2 version 1.37.0')).toEqual([]);
+    });
+    it('accepts kinds the build supports', () => {
+        const features = parseAria2Features(versionOutput);
+        expect(supportsKind(features, 'sftp')).toBe(true);
+        expect(supportsKind(features, 'magnet')).toBe(true);
+    });
+    it('rejects kinds the build lacks', () => {
+        expect(supportsKind(['Async DNS', 'HTTPS'], 'sftp')).toBe(false);
+        expect(supportsKind(['SFTP'], 'torrent')).toBe(false);
+    });
+    it('assumes support when the build is unknown', () => {
+        expect(supportsKind([], 'sftp')).toBe(true);
+    });
+});
+
+describe('aria2 — output hygiene', () => {
+    it('redacts sftp passwords', () => {
+        expect(redactCredentials('sftp://alice:hunter2@host/f.bin')).toBe('sftp://alice:***@host/f.bin');
+    });
+    it('redacts passwords inside longer log lines', () => {
+        const line = 'Download aborted. URI=sftp://alice:hunter2@host:22/srv/f.bin';
+        expect(redactCredentials(line)).toContain('alice:***@host');
+        expect(redactCredentials(line)).not.toContain('hunter2');
+    });
+    it('leaves credential-free URLs alone', () => {
+        expect(redactCredentials('https://example.com/f.iso')).toBe('https://example.com/f.iso');
+    });
+    it('treats banner and legend lines as noise', () => {
+        expect(isAria2Noise('Download Results:')).toBe(true);
+        expect(isAria2Noise('gid   |stat|avg speed  |  %|path/URI')).toBe(true);
+        expect(isAria2Noise('======+====+====')).toBe(true);
+        expect(isAria2Noise('(OK):download completed.')).toBe(true);
+        expect(isAria2Noise('FILE: /tmp/out/secret.bin')).toBe(true);
+    });
+    it('keeps the lines that explain a failure', () => {
+        expect(isAria2Noise('-> [SocketCore.cc:1069] Unexpected SSH host key: expected a, actual b')).toBe(false);
+        expect(isAria2Noise('09/09 04:38 [ERROR] CUID#7 - Download aborted.')).toBe(false);
+    });
+});
+
+// ─── Background jobs ──────────────────────────────────────────────────────────
+
+describe('background — buildChildArgv()', () => {
+    it('drops --background and marks the child', () => {
+        const argv = buildChildArgv(['https://x/f.iso', '--background']);
+        expect(argv).toEqual(['https://x/f.iso', BACKGROUND_CHILD_FLAG]);
+    });
+    it('drops the -b alias too', () => {
+        expect(buildChildArgv(['-b', 'https://x/f.iso'])).toEqual(['https://x/f.iso', BACKGROUND_CHILD_FLAG]);
+    });
+    it('never stacks the child marker twice', () => {
+        const once = buildChildArgv(['https://x/f.iso', '--background']);
+        const twice = buildChildArgv(once);
+        expect(twice.filter(a => a === BACKGROUND_CHILD_FLAG)).toHaveLength(1);
+    });
+    it('keeps every other flag', () => {
+        const argv = buildChildArgv(['sftp://h/f', '-b', '-d', './out', '--seed']);
+        expect(argv).toContain('-d');
+        expect(argv).toContain('./out');
+        expect(argv).toContain('--seed');
+    });
+    it('isBackgroundChild detects the marker', () => {
+        expect(isBackgroundChild(['node', 'grab', BACKGROUND_CHILD_FLAG])).toBe(true);
+        expect(isBackgroundChild(['node', 'grab', 'https://x/f'])).toBe(false);
+    });
+});
+
+describe('background — job registry', () => {
+    let stateDir: string;
+
+    beforeEach(() => {
+        stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grab-jobs-'));
+    });
+    afterEach(() => {
+        try { fs.rmSync(stateDir, { recursive: true, force: true }); } catch { }
+    });
+
+    it('derives log paths under <stateDir>/logs', () => {
+        const logPath = buildLogPath(stateDir, ['https://example.com/ubuntu.iso?x=1']);
+        expect(path.dirname(logPath)).toBe(getLogsDirectory(stateDir));
+        expect(path.basename(logPath)).toContain('ubuntu.iso');
+        expect(logPath.endsWith('.log')).toBe(true);
+    });
+
+    it('lists a job whose process is alive', () => {
+        writeJobRecord(stateDir, {
+            pid: process.pid,
+            urls: ['https://example.com/a.iso'],
+            log: path.join(stateDir, 'a.log'),
+            cwd: stateDir,
+            started: new Date().toISOString(),
+            reason: 'flag',
+        });
+        const jobs = listJobs(stateDir);
+        expect(jobs).toHaveLength(1);
+        expect(jobs[0].urls[0]).toBe('https://example.com/a.iso');
+    });
+
+    it('prunes records whose process has exited', () => {
+        const deadPid = 2 ** 22 - 1; // above any real pid on Linux defaults
+        writeJobRecord(stateDir, {
+            pid: deadPid,
+            urls: ['https://example.com/b.iso'],
+            log: path.join(stateDir, 'b.log'),
+            cwd: stateDir,
+            started: new Date().toISOString(),
+            reason: 'cancel',
+        });
+        expect(listJobs(stateDir)).toHaveLength(0);
+        expect(fs.existsSync(path.join(getJobsDirectory(stateDir), `${deadPid}.json`))).toBe(false);
+    });
+
+    it('returns an empty list when nothing was ever registered', () => {
+        expect(listJobs(stateDir)).toEqual([]);
+    });
+
+    it('isProcessAlive recognises this process', () => {
+        expect(isProcessAlive(process.pid)).toBe(true);
+    });
+});


### PR DESCRIPTION
Adds three new transfer kinds to the `grab-url` CLI and a way to keep long transfers running after you close the terminal.

## SFTP / torrent / magnet — `transfer/aria2-transfer.ts`

`fetch()` speaks neither SFTP nor BitTorrent, so those targets are handed to [`aria2c`](https://aria2.github.io/) and its console readout is parsed into the same cli-progress UI everything else uses (plus connection/seeder counts and a seeding state). Routing:

| Target | Kind |
| --- | --- |
| `sftp://user@host/path/file` | `sftp` |
| `magnet:?xt=urn:btih:…` | `magnet` |
| anything ending `.torrent` (local path or URL) | `torrent` |

Everything else keeps the built-in downloader, and one command can mix both — `grab-url https://a/f.iso ./b.torrent` runs the torrent first, then the file.

New flags: `-d/--dir`, `--seed`, `-c/--connections`, `--user`, `--password`, `--ssh-host-key`, `--aria2-args`. `GRAB_ARIA2_PATH` points at a binary that isn't on `PATH`.

Failure modes are handled up front rather than as a raw aria2 error: a missing `aria2c` prints the per-platform install command, and a build compiled without SFTP/BitTorrent is rejected with the feature list it does have. URI passwords are redacted (`sftp://alice:***@host`) everywhere the CLI echoes a URI — console, background logs, job records — and aria2's banner/legend noise is filtered so the line naming the cause is what you see.

## Background transfers — `background.ts`

```bash
grab-url https://example.com/big.iso --background   # detach now; prints PID + log path
grab-url --jobs                                      # list running jobs, prune finished ones
```

Ctrl+C during any transfer now asks before throwing the work away:

```
🛑 Cancel — keep transferring in the background? [Y/n]
```

**y**/Enter hands off to a detached process that resumes from the partial file; **n** cancels and leaves the resume state in place (exit 130). A second Ctrl+C answers **n**, `--no-bg-prompt` skips the question, and non-interactive shells always cancel outright. The prompt auto-accepts after 15s so a disconnected terminal doesn't strand a download.

Backgrounding re-launches the command as a detached child rather than migrating live sockets, so it rides on the existing resume machinery: HTTP ranges for web downloads, aria2's `.aria2` control file for the rest. Logs and job records live under the download state dir (`.grab-downloads/`, or `GRAB_DOWNLOAD_STATE_DIR`).

## Fixes found along the way

- `ArgParser` split long options on **every** `=` and rejected dash-leading values, mangling `--aria2-args=--max-download-limit=1M`.
- `-d` now also applies to plain downloads, and duplicate-name detection checks the destination directory instead of the cwd.
- API mode no longer creates a `.grab-downloads` state directory for a plain JSON fetch.

## Testing

52 new unit tests (206 total, all passing) cover target detection, the aria2 argument matrix, readout parsing, credential redaction and the job registry. `tsc --noEmit` is clean apart from 4 pre-existing errors in unrelated packages.

Verified live against real servers, not only mocked:

- **SFTP** against a local sshd — checksum match, credentials both inline and via flags, `-o` rename, and a deliberate `--ssh-host-key` mismatch correctly aborting with no file written.
- **Torrent** via a hand-built `.torrent` with a web seed — completed, checksum match.
- **`--background`** end-to-end — parent exits, detached child finishes, `--jobs` lists then prunes it.
- **Ctrl+C → background** on both HTTP and SFTP (driven through a pty) — resumed file matches the source checksum in both cases.
- Readout parsing re-validated against captured output from real aria2c 1.37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fzje5z43zMiJCn6q8dDwKX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fzje5z43zMiJCn6q8dDwKX)_