### PR TITLE
🐛 fix(docs): stop the GitHub Pages Jekyll build from parsing MDX sources

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,36 @@
+# GitHub Pages builds this folder with Jekyll (Settings -> Pages -> "Deploy from
+# a branch", folder /docs). The real documentation site at https://grab.js.org
+# is the Next.js + Fumadocs app that lives here and is built with `next build`,
+# so Jekyll must not try to render its sources.
+#
+# Without this, Jekyll picks up every front-mattered `.mdx` file under content/
+# as a page and runs it through Liquid, which chokes on JSX expressions such as
+# `<TypeTable type={{ ... }} />` and on `{{ user.name }}` inside code samples:
+#
+#   Liquid Exception: Liquid syntax error (line 9): Variable '{{ headers: {
+#   ... }' was not properly terminated with regexp: /\}\}/
+#   in content/docs/grab-options.mdx
+#
+# README.md is excluded for the same reason (its `descriptions={{ ... }}` MDX
+# sample), and because jekyll-readme-index would otherwise publish it as the
+# index page in place of index.html below.
+exclude:
+  - .next
+  - .source
+  - README.md
+  - app
+  - cli.json
+  - components
+  - content
+  - dist
+  - lib
+  - mdx-components.tsx
+  - next-env.d.ts
+  - next.config.ts
+  - node_modules
+  - out
+  - package.json
+  - postcss.config.mjs
+  - proxy.ts
+  - source.config.ts
+  - tsconfig.json

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<!--
+  Placeholder index for the Jekyll-built GitHub Pages site (see _config.yml).
+  The documentation itself is the Next.js + Fumadocs app in this folder, which
+  is deployed to https://grab.js.org — send anyone who lands here there.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GRAB-URL Documentation</title>
+    <link rel="canonical" href="https://grab.js.org/" />
+    <meta http-equiv="refresh" content="0; url=https://grab.js.org/" />
+  </head>
+  <body>
+    <p>
+      The GRAB-URL documentation lives at
+      <a href="https://grab.js.org/">grab.js.org</a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
GitHub Pages publishes /docs from the branch, so `pages build and deployment` runs Jekyll over the Next.js + Fumadocs app that lives there. Jekyll treats every front-mattered `.mdx` file under content/ as a page and renders it through Liquid, which fails on JSX expressions:

  Liquid Exception: Liquid syntax error (line 9): Variable '{{ headers: {
  ... }' was not properly terminated with regexp: /\}\}/
  in content/docs/grab-options.mdx

The same crash was waiting in docs/README.md (`descriptions={{ ... }}`), which jekyll-readme-index promotes to the index page.

Add docs/_config.yml excluding the app sources and README.md from the Jekyll build, plus a static docs/index.html that points at the real documentation site, https://grab.js.org. No MDX content changes — the Fumadocs build was never the thing that was broken.

Verified with jekyll 3.10.0 and the GitHub Pages plugin set: the pre-change tree reproduces the reported Liquid error and exits 1; the post-change tree builds clean and emits _site/index.html.


Claude-Session: https://claude.ai/code/session_01TCpBZdKG1QVfMLtjWSu2Aj