### PR TITLE
💄 Group homepage features grid into categories

### DIFF
--- a/grab-help-docs/components/DocsHomepage/features-grid.tsx
+++ b/grab-help-docs/components/DocsHomepage/features-grid.tsx
@@ -1,6 +1,6 @@
 /**
  * @file features-grid.tsx
- * @description Grid component displaying the key features and benefits of GRAB.
+ * @description Grid component displaying the key features and benefits of GRAB, grouped into categories.
  */
 import Image from "next/image"
 import {
@@ -29,125 +29,157 @@ import {
   Webhook,
 } from "lucide-react"
 
-const features = [
+const categories = [
   {
-    icon: Zap,
-    title: "Auto-JSON Convert",
-    description: "Pass parameters and get response or error in JSON, handling other data types automatically.",
+    name: "Requests & Data",
+    description: "Send anything, get back parsed data — no boilerplate per content type.",
+    features: [
+      {
+        icon: Zap,
+        title: "Auto-JSON Convert",
+        description: "Pass parameters and get response or error in JSON, handling other data types automatically.",
+      },
+      {
+        icon: Braces,
+        title: "DOM Parsing",
+        description: "Automatically parses HTML responses. Pass dom: \"selector\" for CSS extraction or dom: false to disable.",
+      },
+      {
+        icon: PackageOpen,
+        title: "Auto-Unzip",
+        description: "Automatically extracts ZIP responses into { data: { filename: content } }. Set unzip: false to disable.",
+      },
+      {
+        icon: Upload,
+        title: "File Upload",
+        description: "FormData support with base64 conversion option for JSON APIs.",
+      },
+      {
+        icon: Network,
+        title: "Request Hooks",
+        description: "Global onRequest interceptor for auth headers and request modification.",
+      },
+    ],
   },
   {
-    icon: RefreshCw,
-    title: "Reactive Loading",
-    description: "Sets .isLoading=true on response object for React, Vue, Svelte — any framework works.",
+    name: "Reliability & Traffic Control",
+    description: "Keep flaky networks and click-happy users from cascading into your API.",
+    features: [
+      {
+        icon: Clock,
+        title: "Timeout & Retry",
+        description: "Configurable timeout (default 30s) with retryAttempts for auto-retry on failure.",
+      },
+      {
+        icon: RotateCcw,
+        title: "Regrab On Error",
+        description: "Auto-retry on timeout, window refocus, network change, or stale data.",
+      },
+      {
+        icon: Shield,
+        title: "Cancel Duplicates",
+        description: "cancelOngoingIfNew or cancelNewIfOngoing prevents request cascading.",
+      },
+      {
+        icon: Gauge,
+        title: "Rate Limiting",
+        description: "Built-in rate limiting prevents multi-click cascading responses.",
+      },
+      {
+        icon: Repeat,
+        title: "Repeat & Poll",
+        description: "Repeat request X times or poll every X seconds for live updates.",
+      },
+    ],
   },
   {
-    icon: Bug,
-    title: "Debug Logging",
-    description: "Global log() prints colored JSON structure, response timing. Ctrl+I opens DevTools overlay.",
+    name: "Performance & UI State",
+    description: "Fewer round trips, and loading state your components can bind to directly.",
+    features: [
+      {
+        icon: HardDrive,
+        title: "Frontend Cache",
+        description: "Set cache: true for instant repeat requests from browser memory.",
+      },
+      {
+        icon: Infinity,
+        title: "Infinite Scroll",
+        description: "Built-in pagination that auto-loads and merges next page on scroll.",
+      },
+      {
+        icon: RefreshCw,
+        title: "Reactive Loading",
+        description: "Sets .isLoading=true on response object for React, Vue, Svelte — any framework works.",
+      },
+    ],
   },
   {
-    icon: Database,
-    title: "Mock Server",
-    description: "Configure grab.mock for dev/testing. Supports conditional responses and delays.",
+    name: "Testing & Debugging",
+    description: "See every request, fake the ones you don't have yet, and assert on the rest.",
+    features: [
+      {
+        icon: Database,
+        title: "Mock Server",
+        description: "Configure grab.mock for dev/testing. Supports conditional responses and delays.",
+      },
+      {
+        icon: FlaskConical,
+        title: "Jest Testing",
+        description: "Easy unit testing with mock setup and grab.log assertions.",
+      },
+      {
+        icon: Bug,
+        title: "Debug Logging",
+        description: "Global log() prints colored JSON structure, response timing. Ctrl+I opens DevTools overlay.",
+      },
+      {
+        icon: Layers,
+        title: "Request History",
+        description: "All requests stored in grab.log for debugging and analytics.",
+      },
+      {
+        icon: Terminal,
+        title: "CLI Testing",
+        description: "npm i -g grab-url for command line API testing with params and JSON payloads.",
+      },
+    ],
   },
   {
-    icon: Shield,
-    title: "Cancel Duplicates",
-    description: "cancelOngoingIfNew or cancelNewIfOngoing prevents request cascading.",
-  },
-  {
-    icon: Clock,
-    title: "Timeout & Retry",
-    description: "Configurable timeout (default 30s) with retryAttempts for auto-retry on failure.",
-  },
-  {
-    icon: Terminal,
-    title: "CLI Testing",
-    description: "npm i -g grab-url for command line API testing with params and JSON payloads.",
-  },
-  {
-    icon: Layers,
-    title: "Request History",
-    description: "All requests stored in grab.log for debugging and analytics.",
-  },
-  {
-    icon: Infinity,
-    title: "Infinite Scroll",
-    description: "Built-in pagination that auto-loads and merges next page on scroll.",
-  },
-  {
-    icon: Globe,
-    title: "Instance Config",
-    description: "Create separate instances with grab.instance() for different APIs.",
-  },
-  {
-    icon: HardDrive,
-    title: "Frontend Cache",
-    description: "Set cache: true for instant repeat requests from browser memory.",
-  },
-  {
-    icon: RotateCcw,
-    title: "Regrab On Error",
-    description: "Auto-retry on timeout, window refocus, network change, or stale data.",
-  },
-  {
-    icon: Boxes,
-    title: "Framework Agnostic",
-    description: "Works anywhere — React, Vue, Svelte, vanilla JS. No lifecycle hooks needed.",
-  },
-  {
-    icon: FileCode,
-    title: "TypeScript Tooltips",
-    description: "Full type inference with hover tooltips and autocomplete for options.",
-  },
-  {
-    icon: Gauge,
-    title: "Rate Limiting",
-    description: "Built-in rate limiting prevents multi-click cascading responses.",
-  },
-  {
-    icon: Network,
-    title: "Request Hooks",
-    description: "Global onRequest interceptor for auth headers and request modification.",
-  },
-  {
-    icon: Upload,
-    title: "File Upload",
-    description: "FormData support with base64 conversion option for JSON APIs.",
-  },
-  {
-    icon: FlaskConical,
-    title: "Jest Testing",
-    description: "Easy unit testing with mock setup and grab.log assertions.",
-  },
-  {
-    icon: Play,
-    title: "Proxy Support",
-    description: "Node.js proxy support with HttpsProxyAgent for server-side requests.",
-  },
-  {
-    icon: Repeat,
-    title: "Repeat & Poll",
-    description: "Repeat request X times or poll every X seconds for live updates.",
-  },
-  {
-    icon: PackageOpen,
-    title: "Auto-Unzip",
-    description: "Automatically extracts ZIP responses into { data: { filename: content } }. Set unzip: false to disable.",
-  },
-  {
-    icon: Braces,
-    title: "DOM Parsing",
-    description: "Automatically parses HTML responses. Pass dom: \"selector\" for CSS extraction or dom: false to disable.",
-  },
-  {
-    icon: Webhook,
-    title: "OpenAPI SDKs",
-    description: "Generate a typed client or MCP server from any OpenAPI spec — every endpoint gets caching, retries and mocks.",
+    name: "Setup & Integration",
+    description: "Drop it into any stack, any runtime, or generate a whole client from a spec.",
+    features: [
+      {
+        icon: Globe,
+        title: "Instance Config",
+        description: "Create separate instances with grab.instance() for different APIs.",
+      },
+      {
+        icon: Play,
+        title: "Proxy Support",
+        description: "Node.js proxy support with HttpsProxyAgent for server-side requests.",
+      },
+      {
+        icon: Boxes,
+        title: "Framework Agnostic",
+        description: "Works anywhere — React, Vue, Svelte, vanilla JS. No lifecycle hooks needed.",
+      },
+      {
+        icon: FileCode,
+        title: "TypeScript Tooltips",
+        description: "Full type inference with hover tooltips and autocomplete for options.",
+      },
+      {
+        icon: Webhook,
+        title: "OpenAPI SDKs",
+        description: "Generate a typed client or MCP server from any OpenAPI spec — every endpoint gets caching, retries and mocks.",
+      },
+    ],
   },
 ]
 
 export function FeaturesGrid() {
+  let cardIndex = 0
+
   return (
     <section className="relative py-20 md:py-32 border-b border-border overflow-hidden">
       <div className="absolute inset-0 animated-grid-bg opacity-30" />
@@ -173,17 +205,28 @@ export function FeaturesGrid() {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-          {features.map((feature, index) => (
-            <div
-              key={index}
-              className="animated-border-card group p-5 hover:bg-card/80 transition-all duration-300"
-              style={{ animationDelay: `${index * 0.05}s` }}
-            >
-              <div className="relative z-10">
-                <feature.icon className="h-7 w-7 text-primary mb-3 group-hover:scale-110 transition-transform duration-300" />
-                <h3 className="font-semibold mb-1.5 text-foreground text-sm">{feature.title}</h3>
-                <p className="text-xs text-muted-foreground leading-relaxed">{feature.description}</p>
+        <div className="flex flex-col gap-12">
+          {categories.map((category) => (
+            <div key={category.name}>
+              <div className="mb-5 pb-3 border-b border-border">
+                <h3 className="text-xl md:text-2xl font-bold text-foreground">{category.name}</h3>
+                <p className="text-sm text-muted-foreground mt-1">{category.description}</p>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+                {category.features.map((feature) => (
+                  <div
+                    key={feature.title}
+                    className="animated-border-card group p-5 hover:bg-card/80 transition-all duration-300"
+                    style={{ animationDelay: `${cardIndex++ * 0.05}s` }}
+                  >
+                    <div className="relative z-10">
+                      <feature.icon className="h-7 w-7 text-primary mb-3 group-hover:scale-110 transition-transform duration-300" />
+                      <h4 className="font-semibold mb-1.5 text-foreground text-sm">{feature.title}</h4>
+                      <p className="text-xs text-muted-foreground leading-relaxed">{feature.description}</p>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## What

The homepage features grid was a flat wall of 23 cards. This splits it into five labelled categories, each with a short tagline, so a visitor scanning the page can find the capability they came for instead of reading every card.

| Category | Features |
| --- | --- |
| **Requests & Data** | Auto-JSON Convert, DOM Parsing, Auto-Unzip, File Upload, Request Hooks |
| **Reliability & Traffic Control** | Timeout & Retry, Regrab On Error, Cancel Duplicates, Rate Limiting, Repeat & Poll |
| **Performance & UI State** | Frontend Cache, Infinite Scroll, Reactive Loading |
| **Testing & Debugging** | Mock Server, Jest Testing, Debug Logging, Request History, CLI Testing |
| **Setup & Integration** | Instance Config, Proxy Support, Framework Agnostic, TypeScript Tooltips, OpenAPI SDKs |

## Changes

Single file: `grab-help-docs/components/DocsHomepage/features-grid.tsx`

- `features` array becomes `categories`, each with `name`, `description`, and its own `features` list.
- Each category renders a heading block (`h3` + tagline, underlined by a `border-b`) above its own grid; categories are spaced with `flex flex-col gap-12`.
- Card markup, icons, hover states, and grid breakpoints are unchanged. Card titles move from `h3` to `h4` now that the category heading owns the `h3` level.
- The `animationDelay` stagger continues across category boundaries via a running counter, so the cascade still reads as one sweep down the section.

No copy was rewritten and no feature was added or dropped — all 23 are still present, verified by parsing the file for titles (23 found, 0 duplicates).

## Verification

The docs app has no `node_modules` in this environment, so the project typecheck and dev server could not be run. A standalone `tsc` pass over the changed file surfaced only the expected "React types not installed" errors and no syntax or logic errors. **Worth a local `next dev` before merging** to eyeball the new headings and spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxwNU1JS6mcHcacPFNAjda

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxwNU1JS6mcHcacPFNAjda)_