### PR TITLE
📝 docs: group the README and Introduction feature lists into categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,54 @@ npm i grab-url
 
 ### GRAB: Generate Request to API from Browser
 
-1.  **GRAB is the FBEST Request Manager: Functionally Brilliant, Elegantly Simple Tool**: One Function, no dependencies, minimalist syntax, [more features than alternatives](https://grab.js.org/docs/Comparisons)
-2.  **Auto-JSON Convert**: Pass parameters and get response or error in JSON, handling other data types as is.
-3.  **isLoading Status**: Sets `.isLoading=true` on the pre-initialized response object so you can show a "Loading..." in any framework
-4.  **[Agent Skill](https://grab.js.org/docs/claude-skill)** Install the skill into any agent (Claude, Cursor, Gemini, Codex, Antigravity, etc.) with one command: `npx skills add vtempest/GRAB-URL@use-grab-request`. Or copy [SKILL.md](skills/use-grab-request/SKILL.md) into `~/.claude/skills/use-grab-request/SKILL.md`.
-5.  **Mock Server Support**: Configure `window.grab.mock` for development and testing environments
-6.  **Cancel Duplicates**: Prevent this request if one is ongoing to same path & params, or cancel the ongoing request.
-7.  **Timeout & Retry**: Customizable request timeout, default 30s, and auto-retry on error
-8.  **DevTools**: `Ctrl+Alt+I` overlays webpage with devtools showing all requests and responses, timing, and JSON structure.
-9.  **Request History**: Stores all request and response data in global `grab.log` object
-10. **Pagination Infinite Scroll**: Built-in pagination for infinite scroll to auto-load and merge next result page, with scroll position recovery.
-11. **Base URL Based on Environment**: Configure `grab.defaults.baseURL` once at the top, overide with `SERVER_API_URL` in `.env`.
-12. **Frontend Cache**: Set cache headers and retrieve from frontend memory for repeat requests to static data.
-13. **Regrab On Error**: Regrab on timeout error, or on window refocus, or on network change, or on stale data.
-14. **Framework Agnostic**: Alternatives like TanStack work only in component initialization and depend on React & others.
-15. **Globals**: Adds to window in browser or global in Node.js so you only import once: `grab()`, `log()`, `grab.log`, `grab.mock`, `grab.defaults`
-16. **Debug Logging**: Adds global `log()` and prints colored JSON structure, response, timing for requests in test.
-17. **Request Stategies**: [🎯 Examples](https://grab.js.org/docs/examples) show common stategies like debounce, repeat, proxy, unit tests, interceptors, file upload, etc
-18. **Rate Limiting**: Built-in rate limiting to prevent multi-click cascading responses, require to wait seconds between requests.
-19. **Repeat**: Repeat request this many times, or repeat every X seconds to poll for updates.
-20. **Loading Icons**: Import from `grab-url/icons` to get enhanced animated loading icons, including the [quantum sphere](https://grab.js.org/loaders/quantum-sphere) — an interactive 3D orbital loader for React and Svelte that re-rolls its own colors and collapses each ring you hover: `import QuantumOrbital from 'grab-url/icons/quantum-sphere'`.
-21. **Auto-Unzip**: Automatically extracts ZIP responses into `{ data: { filename: content } }` using archiver-web. Set `unzip: false` to disable.
-22. **DOM Parsing**: Automatically parses HTML responses. Pass `parseDOM: "selector"` for CSS selector extraction or `parseDOM: false` to disable. Uses linkedom.
-23. **[OpenAPI SDKs](https://grab.js.org/docs/openapi-services)**: Generate a typed client from any OpenAPI spec with [Hey API](https://heyapi.dev) and have it send requests with grab instead of axios: `npx api2client ./openapi.yaml ./src/client`. Every endpoint gets caching, retries, rate limiting, dedupe and mocks.
+**GRAB is the FBEST Request Manager: Functionally Brilliant, Elegantly Simple Tool** — One Function, no dependencies, minimalist syntax, [more features than alternatives](https://grab.js.org/docs/Comparisons)
+
+#### Requests & Data
+
+_Send anything, get back parsed data — no boilerplate per content type._
+
+- **Auto-JSON Convert**: Pass parameters and get response or error in JSON, handling other data types as is.
+- **Auto-Unzip**: Automatically extracts ZIP responses into `{ data: { filename: content } }` using archiver-web. Set `unzip: false` to disable.
+- **DOM Parsing**: Automatically parses HTML responses. Pass `parseDOM: "selector"` for CSS selector extraction or `parseDOM: false` to disable. Uses linkedom.
+- **Request Stategies**: [🎯 Examples](https://grab.js.org/docs/examples) show common stategies like debounce, repeat, proxy, unit tests, interceptors, file upload, etc
+
+#### Reliability & Traffic Control
+
+_Keep flaky networks and click-happy users from cascading into your API._
+
+- **Cancel Duplicates**: Prevent this request if one is ongoing to same path & params, or cancel the ongoing request.
+- **Timeout & Retry**: Customizable request timeout, default 30s, and auto-retry on error
+- **Regrab On Error**: Regrab on timeout error, or on window refocus, or on network change, or on stale data.
+- **Rate Limiting**: Built-in rate limiting to prevent multi-click cascading responses, require to wait seconds between requests.
+- **Repeat**: Repeat request this many times, or repeat every X seconds to poll for updates.
+
+#### Performance & UI State
+
+_Fewer round trips, and loading state your components can bind to directly._
+
+- **isLoading Status**: Sets `.isLoading=true` on the pre-initialized response object so you can show a "Loading..." in any framework
+- **Frontend Cache**: Set cache headers and retrieve from frontend memory for repeat requests to static data.
+- **Pagination Infinite Scroll**: Built-in pagination for infinite scroll to auto-load and merge next result page, with scroll position recovery.
+- **Loading Icons**: Import from `grab-url/icons` to get enhanced animated loading icons, including the [quantum sphere](https://grab.js.org/loaders/quantum-sphere) — an interactive 3D orbital loader for React and Svelte that re-rolls its own colors and collapses each ring you hover: `import QuantumOrbital from 'grab-url/icons/quantum-sphere'`.
+
+#### Testing & Debugging
+
+_See every request, fake the ones you don't have yet, and assert on the rest._
+
+- **Mock Server Support**: Configure `window.grab.mock` for development and testing environments
+- **DevTools**: `Ctrl+Alt+I` overlays webpage with devtools showing all requests and responses, timing, and JSON structure.
+- **Debug Logging**: Adds global `log()` and prints colored JSON structure, response, timing for requests in test.
+- **Request History**: Stores all request and response data in global `grab.log` object
+
+#### Setup & Integration
+
+_Drop it into any stack, any runtime, or generate a whole client from a spec._
+
+- **[Agent Skill](https://grab.js.org/docs/claude-skill)** Install the skill into any agent (Claude, Cursor, Gemini, Codex, Antigravity, etc.) with one command: `npx skills add vtempest/GRAB-URL@use-grab-request`. Or copy [SKILL.md](skills/use-grab-request/SKILL.md) into `~/.claude/skills/use-grab-request/SKILL.md`.
+- **Globals**: Adds to window in browser or global in Node.js so you only import once: `grab()`, `log()`, `grab.log`, `grab.mock`, `grab.defaults`
+- **Base URL Based on Environment**: Configure `grab.defaults.baseURL` once at the top, overide with `SERVER_API_URL` in `.env`.
+- **Framework Agnostic**: Alternatives like TanStack work only in component initialization and depend on React & others.
+- **[OpenAPI SDKs](https://grab.js.org/docs/openapi-services)**: Generate a typed client from any OpenAPI spec with [Hey API](https://heyapi.dev) and have it send requests with grab instead of axios: `npx api2client ./openapi.yaml ./src/client`. Every endpoint gets caching, retries, rate limiting, dedupe and mocks.
 
 ### Examples
 

--- a/grab-help-docs/content/docs/index.mdx
+++ b/grab-help-docs/content/docs/index.mdx
@@ -39,29 +39,54 @@ npm i grab-url
 
 ### GRAB: Generate Request to API from Browser
 
-1. **GRAB is the FBEST Request Manager: Functionally Brilliant, Elegantly Simple Tool**: One Function, no dependencies, minimalist syntax, [more features than alternatives](https://grab.js.org/docs/Comparisons)
-2. **Auto-JSON Convert**: Pass parameters and get response or error in JSON, handling other data types as is.
-3. **isLoading Status**: Sets `.isLoading=true` on the pre-initialized response object so you can show a "Loading..." in any framework
-4. **[Agent Skill](/docs/claude-skill)** Install the skill into any agent (Claude, Cursor, Gemini, Codex, Antigravity, etc.) with one command: `npx skills add vtempest/GRAB-URL@use-grab-request`.
-5. **Mock Server Support**: Configure `window.grab.mock` for development and testing environments
-6. **Cancel Duplicates**: Prevent this request if one is ongoing to same path & params, or cancel the ongoing request.
-7. **Timeout & Retry**: Customizable request timeout, default 20s, and auto-retry on error
-8. **DevTools**: `Ctrl+Alt+I` overlays webpage with devtools showing all requests and responses, timing, and JSON structure.
-9. **Request History**: Stores all request and response data in global `grab.log` object
-10. **Pagination Infinite Scroll**: Built-in pagination for infinite scroll to auto-load and merge next result page, with scroll position recovery.
-11. **Base URL Based on Environment**: Configure `grab.defaults.baseURL` once at the top, overide with `SERVER_API_URL` in `.env`.
-12. **Frontend Cache**: Set cache headers and retrieve from frontend memory for repeat requests to static data.
-13. **Regrab On Error**: Regrab on timeout error, or on window refocus, or on network change, or on stale data.
-14. **Framework Agnostic**: Alternatives like TanStack work only in component initialization and depend on React & others.
-15. **Globals**: Adds to window in browser or global in Node.js so you only import once: `grab()`, `log()`, `grab.log`, `grab.mock`, `grab.defaults`
-16. **Debug Logging**: Adds global `log()` and prints colored JSON structure, response, timing for requests in test.
-17. **Request Stategies**: [🎯 Examples](https://grab.js.org/docs/Examples) show common stategies like debounce, repeat, proxy, unit tests, interceptors, file upload, etc
-18. **Rate Limiting**: Built-in rate limiting to prevent multi-click cascading responses, require to wait seconds between requests.
-19. **Repeat**: Repeat request this many times, or repeat every X seconds to poll for updates.
-20. **Loading Icons**: Import from `grab-url/icons` to get enhanced animated loading icons, including the [quantum sphere](https://grab.js.org/loaders/quantum-sphere) — an interactive 3D orbital loader for React and Svelte that re-rolls its own colors and collapses each ring you hover: `import QuantumOrbital from 'grab-url/icons/quantum-sphere'`.
-21. **Auto-Unzip**: Automatically extracts ZIP responses into `{ data: { filename: content } }` using archiver-web. Set `unzip: false` to disable.
-22. **DOM Parsing**: Automatically parses HTML responses. Pass `parseDOM: "selector"` for CSS selector extraction or `parseDOM: false` to disable. Uses linkedom.
-23. **[OpenAPI SDKs](/docs/openapi-services)**: Generate a typed client from any OpenAPI spec with [Hey API](https://heyapi.dev) and have it send requests with grab instead of axios: `npx api2client ./openapi.yaml ./src/client`. Every endpoint gets caching, retries, rate limiting, dedupe and mocks.
+**GRAB is the FBEST Request Manager: Functionally Brilliant, Elegantly Simple Tool** — One Function, no dependencies, minimalist syntax, [more features than alternatives](https://grab.js.org/docs/Comparisons)
+
+#### Requests & Data
+
+_Send anything, get back parsed data — no boilerplate per content type._
+
+- **Auto-JSON Convert**: Pass parameters and get response or error in JSON, handling other data types as is.
+- **Auto-Unzip**: Automatically extracts ZIP responses into `{ data: { filename: content } }` using archiver-web. Set `unzip: false` to disable.
+- **DOM Parsing**: Automatically parses HTML responses. Pass `parseDOM: "selector"` for CSS selector extraction or `parseDOM: false` to disable. Uses linkedom.
+- **Request Stategies**: [🎯 Examples](https://grab.js.org/docs/Examples) show common stategies like debounce, repeat, proxy, unit tests, interceptors, file upload, etc
+
+#### Reliability & Traffic Control
+
+_Keep flaky networks and click-happy users from cascading into your API._
+
+- **Cancel Duplicates**: Prevent this request if one is ongoing to same path & params, or cancel the ongoing request.
+- **Timeout & Retry**: Customizable request timeout, default 20s, and auto-retry on error
+- **Regrab On Error**: Regrab on timeout error, or on window refocus, or on network change, or on stale data.
+- **Rate Limiting**: Built-in rate limiting to prevent multi-click cascading responses, require to wait seconds between requests.
+- **Repeat**: Repeat request this many times, or repeat every X seconds to poll for updates.
+
+#### Performance & UI State
+
+_Fewer round trips, and loading state your components can bind to directly._
+
+- **isLoading Status**: Sets `.isLoading=true` on the pre-initialized response object so you can show a "Loading..." in any framework
+- **Frontend Cache**: Set cache headers and retrieve from frontend memory for repeat requests to static data.
+- **Pagination Infinite Scroll**: Built-in pagination for infinite scroll to auto-load and merge next result page, with scroll position recovery.
+- **Loading Icons**: Import from `grab-url/icons` to get enhanced animated loading icons, including the [quantum sphere](https://grab.js.org/loaders/quantum-sphere) — an interactive 3D orbital loader for React and Svelte that re-rolls its own colors and collapses each ring you hover: `import QuantumOrbital from 'grab-url/icons/quantum-sphere'`.
+
+#### Testing & Debugging
+
+_See every request, fake the ones you don't have yet, and assert on the rest._
+
+- **Mock Server Support**: Configure `window.grab.mock` for development and testing environments
+- **DevTools**: `Ctrl+Alt+I` overlays webpage with devtools showing all requests and responses, timing, and JSON structure.
+- **Debug Logging**: Adds global `log()` and prints colored JSON structure, response, timing for requests in test.
+- **Request History**: Stores all request and response data in global `grab.log` object
+
+#### Setup & Integration
+
+_Drop it into any stack, any runtime, or generate a whole client from a spec._
+
+- **[Agent Skill](/docs/claude-skill)** Install the skill into any agent (Claude, Cursor, Gemini, Codex, Antigravity, etc.) with one command: `npx skills add vtempest/GRAB-URL@use-grab-request`.
+- **Globals**: Adds to window in browser or global in Node.js so you only import once: `grab()`, `log()`, `grab.log`, `grab.mock`, `grab.defaults`
+- **Base URL Based on Environment**: Configure `grab.defaults.baseURL` once at the top, overide with `SERVER_API_URL` in `.env`.
+- **Framework Agnostic**: Alternatives like TanStack work only in component initialization and depend on React & others.
+- **[OpenAPI SDKs](/docs/openapi-services)**: Generate a typed client from any OpenAPI spec with [Hey API](https://heyapi.dev) and have it send requests with grab instead of axios: `npx api2client ./openapi.yaml ./src/client`. Every endpoint gets caching, retries, rate limiting, dedupe and mocks.
 
 ### Examples
 


### PR DESCRIPTION
## What

The homepage feature grid (`grab-help-docs/components/DocsHomepage/features-grid.tsx`) is already grouped into five categories, but `README.md` and the docs Introduction page (`grab-help-docs/content/docs/index.mdx`) still listed the same features as a flat 1–23 numbered list. The two surfaces read very differently as a result.

This regroups both prose lists under the grid's existing category headings:

| Category | Features |
|---|---|
| Requests & Data | Auto-JSON Convert, Auto-Unzip, DOM Parsing, Request Stategies |
| Reliability & Traffic Control | Cancel Duplicates, Timeout & Retry, Regrab On Error, Rate Limiting, Repeat |
| Performance & UI State | isLoading Status, Frontend Cache, Pagination Infinite Scroll, Loading Icons |
| Testing & Debugging | Mock Server Support, DevTools, Debug Logging, Request History |
| Setup & Integration | Agent Skill, Globals, Base URL Based on Environment, Framework Agnostic, OpenAPI SDKs |

The FBEST tagline moves out of list slot 1 into a lead paragraph above the categories, since it's a headline rather than a feature.

## Scope

Docs only — no source, config, or build changes.

- Every feature's text is **byte-identical** to before. Verified by diffing the sorted item text in both files against `HEAD`: the only difference is the FBEST tagline being promoted out of the list.
- Each file keeps its own link style — README uses absolute `grab.js.org` URLs, the docs page uses relative `/docs/…` paths — so no links changed target.
- Nothing parses these lists programmatically (`scripts/sync-skill-docs.mjs` only touches `skills/use-grab-request/SKILL.md` → `claude-skill.mdx`), so no generated output shifts.

## Not addressed here

Two pre-existing inconsistencies I noticed but deliberately left alone, since fixing them would mean changing feature text rather than just regrouping it:

- The docs Introduction states the default timeout is **20s**; the README and the grid both say **30s**.
- The prose list and the grid describe overlapping-but-different feature sets — the grid gives File Upload, Request Hooks, Jest Testing, CLI Testing, Instance Config, Proxy Support and TypeScript Tooltips their own cards, while the prose list folds most of those into "Request Stategies".

Happy to follow up on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pfy5FYHtC8WcEnW5rVP5G6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfy5FYHtC8WcEnW5rVP5G6)_