### PR TITLE
🐛 fix(api2client): publish the built dist so the package is importable

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "make:docs": "npx turbo run build --filter=grab-help-docs",
     "make:skill": "node ./scripts/sync-skill-docs.mjs",
     "make:icons": "npx export-svg-typescript@latest -i ./packages/loading-animations/src/svg -o ./packages/loading-animations/src/svg/index.ts",
+    "prepublishOnly": "npm run build",
     "ship": "bun x standard-version --release-as patch;rm CHANGELOG.md; npm publish",
     "test:ui": "vitest --ui",
     "test": "vitest",

--- a/packages/api2client/README.md
+++ b/packages/api2client/README.md
@@ -156,7 +156,7 @@ Reconnects honor the server's `retry:` field and send `Last-Event-ID` from the l
 
 ## Requirements
 
-Works with any `grab-url` ≥ 1.6.22. On 1.6.23 and later it also uses the `onRawResponse` hook to report the response status, headers and parsed error payloads; on older versions those degrade to grab's error message (`"HTTP error: 404 Not Found"`) and a synthesized 200 response. The client detects support and never sends options an older grab would turn into query parameters.
+Needs `grab-url` ≥ 1.6.23 for the `onRawResponse` hook, which is what reports the response status, headers and parsed error payloads. The client detects support and never sends options an older grab would turn into query parameters, so it still runs on 1.6.22 — but there a failed request comes back as grab's error message (`"HTTP error: 404 Not Found"`) with **no `response` at all**, so `result.response.status` throws. Anything that branches on the status needs 1.6.23.
 
 ## What's in this package
 

--- a/packages/api2client/package.json
+++ b/packages/api2client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api2client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Hey API client that sends generated OpenAPI SDK requests with grab instead of axios or fetch, adding caching, retries, rate limiting, deduplication and mocks.",
   "type": "module",
   "main": "./dist/index.cjs.js",
@@ -23,7 +23,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "vite build --config vite.config.ts"
+    "build": "vite build --config vite.config.ts",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "openapi",


### PR DESCRIPTION
api2client@1.0.0 on npm ships only `src/`, while its `exports` point at `./dist/index.es.js` — so `import { createClient } from "api2client"` fails to resolve and nothing that depends on the package can start. The build was simply never run before publishing.

Add `prepublishOnly` to both the root package and api2client so `npm publish` always builds first, and bump api2client to 1.0.1 for the republish.

The same staleness hit grab-url: the `onRawResponse` hook and the `grab.supports` feature flag are in `packages/grab-api/src` but not in the published 1.6.22 bundle, so api2client's feature detection turns itself off and a failed request comes back with no `response` at all. The root `prepublishOnly` is what gets them into the next release. Correct the Requirements section, which claimed those cases degrade to a "synthesized 200 response" — verified against the published tarball, there is no `response` on the result to read a status from.


Claude-Session: https://claude.ai/code/session_01WbQjkZ9G673wV778CZ7iby