### PR TITLE
docs: add architecture guides and agent orientation

### DIFF
--- a/.claude/architecture/build.md
+++ b/.claude/architecture/build.md
@@ -1,0 +1,87 @@
+# The Build
+
+Everything published comes from **one** Vite build at the repo root. There is no
+per-package build step, and `packages/*/package.json` files are mostly metadata —
+editing one does not change what ships.
+
+```bash
+npm run build      # vite build --config vite.config.ts → dist/
+npm run make       # icons → skill docs → docs site → build
+```
+
+`npm run make` is the full refresh:
+
+1. `make:icons` — regenerates `packages/loading-animations/src/svg/index.ts` from
+   the SVG files with `export-svg-typescript`.
+2. `make:skill` — regenerates `grab-help-docs/content/docs/claude-skill.mdx` from
+   `skills/use-grab-request/SKILL.md`.
+3. `make:docs` — `turbo run build --filter=grab-help-docs`.
+4. `build` — the library bundle.
+
+## Entries
+
+Each key becomes `dist/<name>.{es,cjs}.js` plus a `.d.ts`, and is wired into
+`package.json`'s `exports`:
+
+| Entry | From | Exposed as |
+| --- | --- | --- |
+| `grab-api` | `packages/grab-api/src/index.ts` | `grab-url` |
+| `grab-api-slim` | `…/index.slim.ts` | `grab-url/slim` |
+| `animations` | `packages/loading-animations/src/svg/index.ts` | `grab-url/animations` |
+| `quantum-sphere` | `packages/quantum-sphere-loading-animation/src/icons.ts` | `grab-url/icons/quantum-sphere` |
+| `log` | `packages/log-json/src/log-json.ts` | `grab-url/log` |
+| `grab-url-cli` | `packages/grab-url-cli/src/index.ts` | `grab-url/cli`, and the `grab-url`/`grab`/`g` bins |
+| `archiver-web`, `bin-extract`, `bin-compress` | `packages/archiver-web/src/` | `archiver-web` and its bins |
+
+**Adding an entry means editing three places**: `build.lib.entry` in
+`vite.config.ts`, `exports` in `package.json`, and `files` if it needs new source
+shipped.
+
+## Externals — each one is load-bearing
+
+`rollupOptions.external` is a function, not a list, and every branch is there for
+a reason:
+
+- **Node builtins** (`node:*` and the `nodeBuiltins` list) — the CLI is a Node
+  program; bundling these breaks it.
+- **`extract-webpage`** — the optional peer behind `--page`, loaded by runtime
+  `import()`. Bundling it pulls jsdom/linkedom into the CLI.
+- **`react`, `react-dom`, the JSX runtimes** — a second React copy makes every
+  hook in `QuantumOrbital` throw *Invalid hook call*. Only the sphere imports
+  React, so this is a no-op for the other entries.
+- **`jszip`** — always external.
+- **`archiver-web` and `linkedom`, but only when the importer is `index.slim`** —
+  this is what makes the slim build slim. The `importer?.includes("index.slim")`
+  check is the whole mechanism.
+
+## Two traps that have already cost a release
+
+**The `"use client"` directive on the quantum-sphere bundles.** Rollup drops the
+source file's module-level directive when bundling, and a `banner` does not
+survive either — terser re-parses the chunk and discards a directive it reads as
+dead code in an ES module. The `useClientDirective` plugin writes it in
+`generateBundle`, after minification, which is the one point where it sticks.
+Without it, a React Server Component importing the sphere fails on the first
+hook. Do not "simplify" that plugin into a banner.
+
+**Shebangs.** `rollupOptions.output.banner` adds `#!/usr/bin/env node` to
+`grab-url-cli` and the `bin-*` chunks by name. A renamed entry silently loses its
+shebang and the bin stops being executable.
+
+## Aliases
+
+`resolve.alias` maps `@grab-url/log`, `@grab-url/grab-api` **and the published
+name `grab-url`** to the in-repo source, so the generated Hey API client — which
+imports `grab-url` by package name — resolves to the same source inside the
+monorepo as it does for a consumer.
+
+## Tests
+
+Vitest is configured inside `vite.config.ts` (`test.coverage`), with tests in
+`test/*.test.ts` and coverage over `packages/**/src/**`.
+
+```bash
+npm test                 # watch
+npm run test:coverage    # what CI runs
+npm run test:cli         # a real end-to-end download
+```

--- a/.claude/architecture/conventions.md
+++ b/.claude/architecture/conventions.md
@@ -72,8 +72,10 @@ will be missing for consumers while working locally.
 
 ## Agent-specific rules
 
-- Do not put documentation in the root `docs/` folder, and do not delete that
-  folder — see [documentation.md](documentation.md).
+- Do not put documentation in the root `docs/` folder; it is vestigial and on its
+  way out — see [documentation.md](documentation.md).
+- A red Vercel check here is a project misconfiguration, not your diff — every
+  deployment has failed for months. Check before chasing it.
 - Do not edit `grab-help-docs/content/docs/claude-skill.mdx` by hand; edit the
   skill and regenerate.
 - Do not add an import to `grab-api/src/` that is not a Node builtin.

--- a/.claude/architecture/conventions.md
+++ b/.claude/architecture/conventions.md
@@ -1,0 +1,81 @@
+# Conventions and General Rules
+
+## Language and style
+
+- TypeScript, ESM, targeting `es2022`. No framework in `grab-api` — it must work
+  in a browser, in Node and in a Worker.
+- **Zero runtime dependencies in `packages/grab-api/src/`.** Node builtins only.
+  The root `package.json` does carry a few deps (chalk, cli-table3, cli-progress,
+  linkedom) — those are for the CLI and the processors, and they are externalized
+  from the library bundles.
+- Match the surrounding file's style. This codebase documents decisions in
+  `@file` headers and inline comments that name the failure a line prevents
+  (`vite.config.ts` is the clearest example) — write in that register.
+- Prefer adding to an existing entry over creating a new published export; each
+  new entry means edits in `vite.config.ts`, `exports` and `files`.
+
+## Commits
+
+Gitmoji + conventional commits, lowercase subject, imperative mood:
+
+```
+✨ feat(cli): archive a page into a folder with --page
+✨ feat(native-app-wrapper): bundle yt-dlp as a Tauri sidecar
+📝 docs(skill): cover api2ai, the transfer CLI, and the rest of the surface
+💄 feat(homepage): show the full README badge set under the hero tagline
+```
+
+## Pull requests
+
+- Target `master`. One concern per PR.
+- Say what changed and why; note whether the published surface moved.
+- If you changed the skill, confirm `sync-skill-docs.mjs --check` passes.
+
+## Tests
+
+```bash
+npm test                 # vitest, watch
+npm run test:coverage    # what CI runs
+npm run test:cli         # a real download, end to end
+```
+
+Tests live in `test/*.test.ts`; coverage is over `packages/**/src/**`, configured
+inside `vite.config.ts`. Add tests for behaviour changes — especially in
+`flow-control.ts` and the transfer layer, where the failure modes are timing and
+network shaped and only a test pins them down.
+
+## CI
+
+| Workflow | Trigger | What it guards |
+| --- | --- | --- |
+| `tests.yml` | push to master, PR | `npm install` then `npm run test:coverage`, uploaded to Codecov |
+| `pages.yml` | changes to `grab-help-docs/`, `packages/`, the lockfile | Static-exports the docs and publishes to GitHub Pages. Uses `npm ci` deliberately. |
+| `npm-publish.yml` | push to master | Publishes to npm |
+
+## Publishing
+
+`prepublishOnly` runs the build, so `dist/` in a publish always matches source.
+`npm run ship` is the maintainer's release path (standard-version patch bump,
+drops the regenerated changelog, publishes).
+
+`files` controls what is shipped: `dist`, `src`, the yt-dlp installer, and the
+CLI spinner frame data. A new runtime-loaded asset has to be added there or it
+will be missing for consumers while working locally.
+
+## Security
+
+- Never commit secrets, credentials or API keys.
+- `postinstall` downloads a yt-dlp binary (`scripts/install-yt-dlp.mjs`). Treat
+  changes to it as security-relevant: it fetches and executes a third-party
+  binary on every consumer's machine.
+- The license is PROSPER; contributions are under it.
+
+## Agent-specific rules
+
+- Do not put documentation in the root `docs/` folder, and do not delete that
+  folder — see [documentation.md](documentation.md).
+- Do not edit `grab-help-docs/content/docs/claude-skill.mdx` by hand; edit the
+  skill and regenerate.
+- Do not add an import to `grab-api/src/` that is not a Node builtin.
+- Do not turn the runtime `import()` of `extract-webpage` into a static import.
+- Use npm, not bun or yarn.

--- a/.claude/architecture/documentation.md
+++ b/.claude/architecture/documentation.md
@@ -4,20 +4,50 @@ All documentation lives in the user guide, **`grab-help-docs/content/docs`** —
 Next.js + Fumadocs app. Nothing else in this repo is documentation prose, with
 the package `README.md`s and the agent skill as the two deliberate exceptions.
 
-## `docs/` at the root is not a docs folder
+## `docs/` at the root is vestigial
 
-It holds exactly three files and no documentation: `_config.yml`, an
-`index.html` that redirects to grab.js.org, and a `README.md` explaining itself.
+It holds three files and no documentation: a Jekyll `_config.yml`, an
+`index.html` redirect to grab.js.org, and a `README.md` describing itself.
 
-GitHub Pages' "Deploy from a branch" mode accepts only the repository root or a
-folder literally named `/docs`, so the folder stays behind as a deployment stub
-while that setting is in use; `_config.yml` also keeps Jekyll from choking on
-content it cannot parse. **Do not put documentation in it, and do not delete it**
-while Settings → Pages → Source is still "Deploy from a branch" — the Pages
-deploy goes with it.
+They are left over from when GitHub Pages deployed from a branch folder — `/docs`
+being the only folder name Pages accepts besides the repository root. **Pages no
+longer works that way.** Settings → Pages → Source is "GitHub Actions", and
+`.github/workflows/pages.yml` publishes the static export built from
+`grab-help-docs/out`. Nothing reads `docs/` at all.
 
-It becomes removable the moment Pages' Source is switched to "GitHub Actions",
-which is what `.github/workflows/pages.yml` is waiting for.
+Verify that claim rather than trusting this paragraph, or the folder's own
+README: the `Deploy docs to Pages` workflow ends in `actions/deploy-pages@v5`,
+which **only succeeds when Source is "GitHub Actions"**, and it is green on
+`master`. If it is passing, the folder is inert.
+
+The folder's `README.md` and `_config.yml` still assert that Pages builds them
+with Jekyll. That is stale, and it is load-bearing stale: it is the stated reason
+the folder exists. PR #47 corrects those files and then deletes the folder.
+
+So: put no documentation here, and do not recreate it once it is gone.
+
+## The Vercel deploy is broken, and `docs/` is why
+
+Every deployment of the `grab-url` Vercel project is failing, production
+included, and has been since the docs app was renamed `docs/` → `grab-help-docs/`.
+
+The project's **Root Directory is still `docs`**. Turbo resolves no package from
+there (`docs/` matches neither `packages/*` nor `grab-help-docs` in the workspace
+globs), so it reports `No tasks were executed as part of this run`, never writes
+a `.next`, and Vercel fails with:
+
+```
+The file "/vercel/path0/docs/.next/routes-manifest.json" couldn't be found.
+```
+
+**This is a dashboard setting, not a diff — no commit can fix it.** Set Root
+Directory to `grab-help-docs`, clear the `npm install --prefix=..` Install
+Command override, and leave Build Command unset; `grab-help-docs/vercel.json`
+supplies all three. Deleting `docs/` does not fix it either — it only changes the
+error to a missing-root-directory one.
+
+Until that setting changes, a red Vercel check on a PR here says nothing about
+that PR.
 
 ## Adding a page
 
@@ -48,8 +78,8 @@ the next `npm run make`.
 
 | Target | Built by | Notes |
 | --- | --- | --- |
-| **https://grab.js.org** (Vercel) | `grab-help-docs/vercel.json` → `turbo run build --filter=grab-help-docs` | The full app — middleware, a Server Action and a POST route handler all work. The Vercel project's **Root Directory must be `grab-help-docs`**; left at `docs/` the deploy fails with `The file "…/docs/.next/routes-manifest.json" couldn't be found`. |
-| **GitHub Pages** | `.github/workflows/pages.yml` → `grab-help-docs/scripts/build-static-pages.mjs` | A static export. `output: 'export'` supports none of those three server pieces, so the script **prunes them from the working tree** before building. It is destructive by design and refuses to run outside CI without `--force`. |
+| **https://grab.js.org** (Vercel) | `grab-help-docs/vercel.json` → `turbo run build --filter=grab-help-docs` | The full app — middleware, a Server Action and a POST route handler all work. **Currently failing**: Root Directory is still `docs`. See the section above. |
+| **GitHub Pages** | `.github/workflows/pages.yml` → `grab-help-docs/scripts/build-static-pages.mjs` → `actions/deploy-pages@v5` | A static export, served from `grab-help-docs/out`. `output: 'export'` supports none of those three server pieces, so the script **prunes them from the working tree** before building. It is destructive by design and refuses to run outside CI without `--force`. Green on `master`. |
 
 The Pages workflow uses `npm ci`, not a floating install: `package-lock.json`
 pins a compatible `fumadocs-openapi` / `fumadocs-ui` pair and a fresh resolve

--- a/.claude/architecture/documentation.md
+++ b/.claude/architecture/documentation.md
@@ -1,0 +1,63 @@
+# Documentation — Where It Goes
+
+All documentation lives in the user guide, **`grab-help-docs/content/docs`** — a
+Next.js + Fumadocs app. Nothing else in this repo is documentation prose, with
+the package `README.md`s and the agent skill as the two deliberate exceptions.
+
+## `docs/` at the root is not a docs folder
+
+It holds exactly three files and no documentation: `_config.yml`, an
+`index.html` that redirects to grab.js.org, and a `README.md` explaining itself.
+
+GitHub Pages' "Deploy from a branch" mode accepts only the repository root or a
+folder literally named `/docs`, so the folder stays behind as a deployment stub
+while that setting is in use; `_config.yml` also keeps Jekyll from choking on
+content it cannot parse. **Do not put documentation in it, and do not delete it**
+while Settings → Pages → Source is still "Deploy from a branch" — the Pages
+deploy goes with it.
+
+It becomes removable the moment Pages' Source is switched to "GitHub Actions",
+which is what `.github/workflows/pages.yml` is waiting for.
+
+## Adding a page
+
+1. Write `grab-help-docs/content/docs/<slug>.mdx` with frontmatter — `title` is
+   required by `frontmatterSchema` in `source.config.ts`; `icon` takes a Lucide
+   name.
+2. Add the slug to `content/docs/meta.json`. Sections are `---Label---`
+   separators; a subdirectory is included with `...<dir>` and needs its own
+   `meta.json`.
+3. MDX rules apply: a bare `{` or `<` outside a code fence is parsed as JSX —
+   this is the specific reason Jekyll is kept away from the real docs.
+
+## The generated skill page
+
+`content/docs/claude-skill.mdx` is **generated**. The source of truth is
+`skills/use-grab-request/SKILL.md`; `scripts/sync-skill-docs.mjs` regenerates the
+page and writes the header telling you so.
+
+```bash
+npm run make:skill            # regenerate
+node scripts/sync-skill-docs.mjs --check   # fail if stale, instead of writing
+```
+
+Edit the skill, regenerate, commit both. Editing the `.mdx` directly is undone by
+the next `npm run make`.
+
+## Two deployments, one source
+
+| Target | Built by | Notes |
+| --- | --- | --- |
+| **https://grab.js.org** (Vercel) | `grab-help-docs/vercel.json` → `turbo run build --filter=grab-help-docs` | The full app — middleware, a Server Action and a POST route handler all work. The Vercel project's **Root Directory must be `grab-help-docs`**; left at `docs/` the deploy fails with `The file "…/docs/.next/routes-manifest.json" couldn't be found`. |
+| **GitHub Pages** | `.github/workflows/pages.yml` → `grab-help-docs/scripts/build-static-pages.mjs` | A static export. `output: 'export'` supports none of those three server pieces, so the script **prunes them from the working tree** before building. It is destructive by design and refuses to run outside CI without `--force`. |
+
+The Pages workflow uses `npm ci`, not a floating install: `package-lock.json`
+pins a compatible `fumadocs-openapi` / `fumadocs-ui` pair and a fresh resolve
+picks versions that break the build.
+
+## Package READMEs and the root README
+
+Each `packages/*/README.md` documents that folder's own surface. The root
+`README.md` is the npm landing page and the feature list — when you add a
+user-visible capability, it belongs there, in the relevant docs page, and in the
+skill if an agent would use it.

--- a/.claude/architecture/overview.md
+++ b/.claude/architecture/overview.md
@@ -1,0 +1,73 @@
+# Architecture Overview
+
+One npm package (`grab-url`) built from several source folders under
+`packages/`, plus a documentation site and an agent skill. There is no
+per-package build: the root `vite.config.ts` compiles every entry into one
+`dist/`, and `package.json`'s `exports` map is the public surface.
+
+## The packages
+
+| Folder | Published as | What it is |
+| --- | --- | --- |
+| `grab-api` | the `grab-url` main entry | The `grab()` function. Zero runtime dependencies — that is the product claim. |
+| `grab-url-cli` | `grab-url` / `grab` / `g` bins | The download CLI: HTTP, SFTP, torrents/magnets (aria2c), 700+ media sites (yt-dlp), page archiving. |
+| `archiver-web` | `archiver-web`, `grab-url/…` bins | ZIP extract/create on JSZip. Frontend-only, no WASM. Powers auto-unzip. |
+| `api2client` | `api2client` | Generates a typed client from an OpenAPI spec with Hey API, wired to send through `grab` instead of axios. |
+| `log-json` | `grab-url/log` | `log()` — the colored JSON structure printer and request history. |
+| `loading-animations` | `grab-url/animations` | Tree-shakable SVG spinners plus CLI terminal spinner frames. |
+| `quantum-sphere-loading-animation` | `grab-url/icons/quantum-sphere` | The 3D orbital loader, React and Svelte. |
+| `native-app-wrapper` | `native-app-wrapper` | Tauri scaffold packaging a site or a bundled CLI as a desktop/mobile app, driven by one JSON profile. Ships grab-url's downloader with yt-dlp as a sidecar. **Excluded from the workspace globs** (`"!packages/native-app-wrapper"`) — it installs and builds on its own. |
+
+## Inside `grab-api`
+
+```
+src/index.ts              the grab() entry and the instance factory
+src/index.slim.ts         the same, with the heavy processors externalized
+src/core/
+  core.ts                 the request lifecycle
+  request-prep.ts         params, headers, baseURL, body encoding
+  request-executor.ts     the fetch call (…-slim.ts is the trimmed variant)
+  flow-control.ts         dedupe, cancel, rate limit, timeout, retry
+  cache-pagination.ts     the frontend cache and infinite-scroll paging
+  regrab-events.ts        refetch on refocus / network change / stale
+  content-processors.ts   auto-JSON, auto-unzip, DOM parsing
+src/response/
+  response-handler.ts     shaping { data, error, isLoading } onto the response object
+  infinite-scroll.ts      merging the next page, scroll position recovery
+src/devtools/devtools.ts  the Ctrl+Alt+I overlay
+src/common/{types,utils}.ts
+```
+
+A request runs: `request-prep` → `flow-control` (may short-circuit on dedupe,
+rate limit or cache) → `request-executor` → `content-processors` →
+`response-handler`. The response object is pre-initialized and mutated, which is
+why `.isLoading` can be bound by any framework without a hook.
+
+**Slim vs full.** `index.slim.ts` is a second entry that externalizes
+`archiver-web` and `linkedom`, for consumers who do not want unzip and DOM
+parsing pulled in. A change in `content-processors.ts` usually needs a matching
+thought about whether the slim build still resolves.
+
+## Inside `grab-url-cli`
+
+```
+src/index.ts              arg parsing → dispatch
+src/cli-args.ts           the flag surface
+src/transfer/
+  media-domains.ts        which URLs get routed to yt-dlp (700+ domains)
+  ytdlp-transfer.ts       yt-dlp, ytdlp-binary.ts installs/locates it
+  aria2-transfer.ts       torrents and magnet links
+  single-file-transfer.ts / multi-file-transfer.ts
+  resume-state.ts         resumable transfers
+src/page/                 --page: archive an article into ./<Page Title>/
+src/background.ts         detach and keep going
+src/keyboard-controls.ts  Ctrl+C offering resume/background rather than dying
+src/display/, download-spinners.ts, cancel-state.ts
+```
+
+`--page` loads **`extract-webpage`** (the qwksearch extractor) through a runtime
+`import()`. It is an optional peer dependency and must never enter the bundle —
+it drags in jsdom/linkedom. `extract-webpage-loader.ts` exists to keep that
+boundary; do not turn it into a static import.
+
+yt-dlp is installed by `scripts/install-yt-dlp.mjs`, which runs on `postinstall`.

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,9 @@ test/test-downloads
 .vercel
 .grab-downloads/
 grab-help-docs/dist/
-.claude
+.claude/*
+# Architecture notes for Claude agents — checked in on purpose (see CLAUDE.md)
+!.claude/architecture
 build.log
 pnpm-lock.yaml
 .turbo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,9 @@ generator, loading animations, and a Tauri wrapper.
 3. **Zero runtime dependencies in `grab-api`.** That is the product claim. Adding
    an import to `packages/grab-api/src/` that is not a Node builtin breaks it.
 4. **Documentation goes in the user guide**, `grab-help-docs/content/docs`.
-   Do **not** put documentation in the root `docs/` folder — it is a GitHub Pages
-   deployment stub with no documentation in it. See
+   The root `docs/` folder holds no documentation — it is a vestigial Jekyll stub
+   from before GitHub Pages switched to deploying via Actions, and PR #47 removes
+   it. Put nothing there, and do not recreate it. See
    [`architecture/documentation.md`](.claude/architecture/documentation.md).
 5. **The skill is generated.** `grab-help-docs/content/docs/claude-skill.mdx` is
    written from `skills/use-grab-request/SKILL.md` — edit the skill, then run
@@ -75,5 +76,5 @@ npm run test:cli            # a real download, end to end
 | --- | --- |
 | [overview.md](.claude/architecture/overview.md) | What each package does and how a request flows through `grab()` |
 | [build.md](.claude/architecture/build.md) | The single root build, entries, externals, and the traps in it |
-| [documentation.md](.claude/architecture/documentation.md) | The Fumadocs site, the two deployments, why root `docs/` exists |
+| [documentation.md](.claude/architecture/documentation.md) | The Fumadocs site, the two deployments, the vestigial root `docs/`, and the broken Vercel setting |
 | [conventions.md](.claude/architecture/conventions.md) | Code style, commits, PRs, CI, publishing |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md — GRAB-URL
+
+Orientation for Claude agents working in this repository. Read this first; the
+detailed notes live in [`.claude/architecture/`](.claude/architecture/).
+
+**GRAB — Generate Request to API from Browser.** One `grab()` function with no
+runtime dependencies that replaces a request library: auto-JSON, auto-unzip, DOM
+parsing, dedupe, retry, timeout, rate limiting, caching, infinite scroll, mocks
+and a devtools overlay. Around it: a media-downloading CLI, an OpenAPI client
+generator, loading animations, and a Tauri wrapper.
+
+## Ground rules
+
+1. **npm, not bun or yarn.** `packageManager` pins `npm@11.19.1` and CI runs
+   `npm install`. The Pages workflow uses `npm ci` deliberately — a floating
+   resolve picks an incompatible fumadocs pair. Commit `package-lock.json`.
+2. **The published package has one build, from the repo root.** `packages/*` are
+   source folders, not independently published packages — `vite.config.ts` at the
+   root compiles all of them into one `dist/`. See
+   [`architecture/build.md`](.claude/architecture/build.md).
+3. **Zero runtime dependencies in `grab-api`.** That is the product claim. Adding
+   an import to `packages/grab-api/src/` that is not a Node builtin breaks it.
+4. **Documentation goes in the user guide**, `grab-help-docs/content/docs`.
+   Do **not** put documentation in the root `docs/` folder — it is a GitHub Pages
+   deployment stub with no documentation in it. See
+   [`architecture/documentation.md`](.claude/architecture/documentation.md).
+5. **The skill is generated.** `grab-help-docs/content/docs/claude-skill.mdx` is
+   written from `skills/use-grab-request/SKILL.md` — edit the skill, then run
+   `npm run make:skill`.
+6. **Never commit secrets**, credentials, API keys, or `dist/` changes that did
+   not come from a build.
+
+## Where things live
+
+| You want to change… | Go to |
+| --- | --- |
+| The `grab()` request function | `packages/grab-api/src/` |
+| The `grab-url` download CLI | `packages/grab-url-cli/src/` |
+| ZIP extract/create | `packages/archiver-web/src/` |
+| The OpenAPI → client generator | `packages/api2client/` |
+| `log()` and the JSON printer | `packages/log-json/src/` |
+| SVG / CLI spinners | `packages/loading-animations/src/` |
+| The 3D orbital loader | `packages/quantum-sphere-loading-animation/` |
+| The Tauri desktop/mobile wrapper | `packages/native-app-wrapper/` (not in the workspace globs) |
+| Build entries, externals, bundling | `vite.config.ts` at the root |
+| Documentation | `grab-help-docs/content/docs/` |
+| The agent skill | `skills/use-grab-request/SKILL.md` |
+
+Full map: [`architecture/overview.md`](.claude/architecture/overview.md).
+
+## Commands
+
+```bash
+npm install                 # never bun/yarn
+npm run build               # vite build — the whole dist/
+npm run make                # icons → skill → docs → build (the full refresh)
+npm test                    # vitest
+npm run test:coverage       # as CI runs it
+npm run test:cli            # a real download, end to end
+```
+
+## Before you open a PR
+
+- `npm run test:coverage`, and `npm run build` if you touched anything bundled.
+- If you changed the skill, run `npm run make:skill` and commit the regenerated
+  docs page; `--check` fails when it is stale.
+- Commit style is **gitmoji + conventional commits**:
+  `✨ feat(cli): archive a page into a folder with --page`. See
+  [`architecture/conventions.md`](.claude/architecture/conventions.md).
+- Target `master`. Keep the PR focused.
+
+## Detailed notes
+
+| Note | Covers |
+| --- | --- |
+| [overview.md](.claude/architecture/overview.md) | What each package does and how a request flows through `grab()` |
+| [build.md](.claude/architecture/build.md) | The single root build, entries, externals, and the traps in it |
+| [documentation.md](.claude/architecture/documentation.md) | The Fumadocs site, the two deployments, why root `docs/` exists |
+| [conventions.md](.claude/architecture/conventions.md) | Code style, commits, PRs, CI, publishing |


### PR DESCRIPTION
Add comprehensive documentation for Claude agents and developers working in this repository, establishing clear conventions and architectural patterns.

## Summary
This PR introduces a new `.claude/architecture/` directory with detailed guides covering the repository structure, build system, conventions, and documentation practices. It also adds a top-level `CLAUDE.md` file as the entry point for agent orientation.

## Changes
- **CLAUDE.md** — Quick orientation guide for Claude agents with ground rules, package locations, commands, and links to detailed notes
- **.claude/architecture/overview.md** — High-level architecture explaining the monorepo structure, package purposes, and request flow through `grab()`
- **.claude/architecture/build.md** — Deep dive into the single root Vite build, entry points, externals configuration, and two critical traps (the `"use client"` directive and shebangs)
- **.claude/architecture/conventions.md** — Code style, commit format (gitmoji + conventional), PR guidelines, testing strategy, CI workflows, and publishing process
- **.claude/architecture/documentation.md** — Where documentation lives, the role of the root `docs/` folder as a GitHub Pages stub, how to add pages, and the two deployment targets (Vercel and GitHub Pages)
- **.gitignore** — Updated to preserve `.claude/architecture/` while ignoring other `.claude/` contents

## Implementation Details
- The `.claude/` directory is now partially tracked: `.claude/*` is ignored, but `!.claude/architecture` is explicitly included, allowing architecture notes to be version-controlled while keeping other agent-specific files local
- Documentation emphasizes critical constraints: zero runtime dependencies in `grab-api`, the single root build, and the generated nature of the skill documentation
- Guides document known failure modes and their solutions (e.g., why the `useClientDirective` plugin cannot be simplified into a banner)

https://claude.ai/code/session_01Dvhttfj3zusx2tdHxy1FkT