### PR TITLE
📝 docs(claude): tidy the four loose ends left by the #47/#48/#49 merges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,9 +43,6 @@ test/test-downloads
 .vercel
 .grab-downloads/
 grab-help-docs/dist/
-.claude/*
-# Architecture notes for Claude agents — checked in on purpose (see CLAUDE.md)
-!.claude/architecture
 build.log
 pnpm-lock.yaml
 .turbo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,9 @@ generator, loading animations, and a Tauri wrapper.
 3. **Zero runtime dependencies in `grab-api`.** That is the product claim. Adding
    an import to `packages/grab-api/src/` that is not a Node builtin breaks it.
 4. **Documentation goes in the user guide**, `grab-help-docs/content/docs`.
-   The root `docs/` folder holds no documentation — it is a vestigial Jekyll stub
-   from before GitHub Pages switched to deploying via Actions, and PR #47 removes
-   it. Put nothing there, and do not recreate it. See
+   The root `docs/` folder is gone — it was a vestigial Jekyll stub from before
+   GitHub Pages switched to deploying via Actions, and #47 deleted it. Put
+   nothing there, and do not recreate it. See
    [`architecture/documentation.md`](.claude/architecture/documentation.md).
 5. **The skill is generated.** `grab-help-docs/content/docs/claude-skill.mdx` is
    written from `skills/use-grab-request/SKILL.md` — edit the skill, then run
@@ -78,3 +78,7 @@ npm run test:cli            # a real download, end to end
 | [build.md](.claude/architecture/build.md) | The single root build, entries, externals, and the traps in it |
 | [documentation.md](.claude/architecture/documentation.md) | The Fumadocs site, the two deployments, the vestigial root `docs/`, and the broken Vercel setting |
 | [conventions.md](.claude/architecture/conventions.md) | Code style, commits, PRs, CI, publishing |
+| [monorepo.md](.claude/architecture/monorepo.md) | Workspaces, npm vs pnpm, which packages actually publish, where the tests live |
+
+Each `packages/*` folder and `grab-help-docs` also has its own `CLAUDE.md` with
+the rules and traps specific to working in it.

--- a/grab-help-docs/CLAUDE.md
+++ b/grab-help-docs/CLAUDE.md
@@ -26,7 +26,13 @@ npm run make:docs     # turbo run build --filter=grab-help-docs
 in a comment at the top. Edit the skill, then `npm run make:skill`.
 `node scripts/sync-skill-docs.mjs --check` fails when it is stale.
 
-## Not to be confused with
+## The root `docs/` folder is gone
 
-The root `docs/` directory — a small static landing page for grab.js.org
-(`index.html`, `_config.yml`). Documentation does not go there.
+It was a vestigial Jekyll stub from before GitHub Pages switched to deploying
+via Actions, and #47 deleted it. **Do not recreate it** — documentation belongs
+here, in `content/docs/`.
+
+It is still worth knowing about, because the Vercel project's Root Directory
+points at that now-missing folder and every deploy fails as a result. See
+[`../.claude/architecture/documentation.md`](../.claude/architecture/documentation.md);
+it is a dashboard setting, so no commit here can fix it.

--- a/packages/grab-api/CLAUDE.md
+++ b/packages/grab-api/CLAUDE.md
@@ -8,6 +8,12 @@ So its public API is `grab-url`'s public API. There is no separate
 `@grab-url/grab-api` for anyone to install, and a breaking change here is a
 breaking change to the published package.
 
+## Zero runtime dependencies
+
+That is the product claim for `grab()`, and it is a repo-wide ground rule. An
+import added to this package's `src/` that is not a Node builtin breaks it —
+check before reaching for a helper library.
+
 ## Two entries, and the difference is the point
 
 | Source | Ships as | Difference |


### PR DESCRIPTION
Follow-up to #49, which merged at 13:59 while this reconciliation was still being written — so these four fixes missed it by about a minute. #49 is merged and can't carry them, hence a fresh PR.

Four files, +22/−9, documentation only.

## What's wrong on `master` right now

**1. `.gitignore` carries both PRs' `.claude` blocks, stacked**

#48 and #49 each added one and the merge kept both:

```
.claude/*
# Architecture notes for Claude agents — checked in on purpose (see CLAUDE.md)
!.claude/architecture
…
.claude/*
# Agent docs for Claude Code — checked in on purpose (see CLAUDE.md)
!.claude/architecture
!.claude/settings.json
.claude/settings.local.json
CLAUDE.local.md
```

Collapsed to the second, which is a superset — it keeps the un-ignore that makes `.claude/settings.json` trackable and the local-only excludes.

**2. `CLAUDE.md` ground rule 4 says #47 "removes" `docs/`**

#47 merged; the folder is gone. Changed to past tense.

**3. `grab-help-docs/CLAUDE.md` still describes `docs/` as a live landing page**

> The root `docs/` directory — a small static landing page for grab.js.org

It no longer exists. Rewritten around what still matters: it's deleted, don't recreate it, and the Vercel project's Root Directory still points at the missing folder — with a pointer to `documentation.md`, which has the dashboard fix.

**4. Nothing referenced the per-package `CLAUDE.md` files or `monorepo.md`**

#49 added nine per-package files and `monorepo.md`, but the root `CLAUDE.md` — which came from #48 — has no pointer to either, so an agent reading it never learns they exist. Added a row and a line to the Detailed-notes section.

## Also

`packages/grab-api/CLAUDE.md` now carries the **zero-runtime-dependencies** claim that #48 raised to a repo-wide ground rule. It's the single most important constraint on that package and its own file didn't state it.

## Verification

- All four confirmed live on `master` before fixing, and confirmed fixed here.
- `.claude/settings.json` still tracked after the `.gitignore` collapse; all 6 `.claude` files still tracked.
- Every `.claude/architecture/*.md` link in `CLAUDE.md` resolves.
- No code touched — `test/` and `packages/grab-url-cli/src/` are untouched, so the 11 pre-existing failures in `test/page-archive.test.ts` (red on `master` since #45) are unchanged, as is the Vercel check, whose Root Directory is a dashboard setting no commit can fix. Both were diagnosed in the #49 comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoGK1G8bnF6riGQekWLtYr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoGK1G8bnF6riGQekWLtYr)_