### PR TITLE
🐛 fix(publish): point repository URLs at OpenSourceAGI so provenance validates

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "rights.institute/prosper",
   "repository": {
     "type": "git",
-    "url": "https://github.com/vtempest/GRAB-URL"
+    "url": "https://github.com/OpenSourceAGI/GRAB-URL"
   },
   "workspaces": [
     "packages/*",

--- a/packages/api2client/package.json
+++ b/packages/api2client/package.json
@@ -60,11 +60,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vtempest/GRAB-URL.git",
+    "url": "git+https://github.com/OpenSourceAGI/GRAB-URL.git",
     "directory": "packages/api2client"
   },
   "bugs": {
-    "url": "https://github.com/vtempest/GRAB-URL/issues"
+    "url": "https://github.com/OpenSourceAGI/GRAB-URL/issues"
   },
-  "homepage": "https://github.com/vtempest/GRAB-URL/tree/master/packages/api2client#readme"
+  "homepage": "https://github.com/OpenSourceAGI/GRAB-URL/tree/master/packages/api2client#readme"
 }

--- a/packages/archiver-web/package.json
+++ b/packages/archiver-web/package.json
@@ -30,11 +30,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vtempest/GRAB-URL.git",
+    "url": "git+https://github.com/OpenSourceAGI/GRAB-URL.git",
     "directory": "packages/archiver-web"
   },
   "bugs": {
-    "url": "https://github.com/vtempest/GRAB-URL/issues"
+    "url": "https://github.com/OpenSourceAGI/GRAB-URL/issues"
   },
-  "homepage": "https://github.com/vtempest/GRAB-URL/tree/master/packages/archiver-web#readme"
+  "homepage": "https://github.com/OpenSourceAGI/GRAB-URL/tree/master/packages/archiver-web#readme"
 }

--- a/packages/loading-animations/package.json
+++ b/packages/loading-animations/package.json
@@ -38,13 +38,13 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vtempest/GRAB-URL.git",
+    "url": "git+https://github.com/OpenSourceAGI/GRAB-URL.git",
     "directory": "packages/loading-animations"
   },
   "bugs": {
-    "url": "https://github.com/vtempest/GRAB-URL/issues"
+    "url": "https://github.com/OpenSourceAGI/GRAB-URL/issues"
   },
-  "homepage": "https://github.com/vtempest/GRAB-URL/tree/master/packages/loading-animations#readme",
+  "homepage": "https://github.com/OpenSourceAGI/GRAB-URL/tree/master/packages/loading-animations#readme",
   "devDependencies": {
     "typescript": "^5.0.0",
     "vite": "^7.3.1",

--- a/packages/quantum-sphere-loading-animation/package.json
+++ b/packages/quantum-sphere-loading-animation/package.json
@@ -55,13 +55,13 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vtempest/GRAB-URL.git",
+    "url": "git+https://github.com/OpenSourceAGI/GRAB-URL.git",
     "directory": "packages/quantum-sphere-loading-animation"
   },
   "bugs": {
-    "url": "https://github.com/vtempest/GRAB-URL/issues"
+    "url": "https://github.com/OpenSourceAGI/GRAB-URL/issues"
   },
-  "homepage": "https://github.com/vtempest/GRAB-URL/tree/master/packages/quantum-sphere-loading-animation#readme",
+  "homepage": "https://github.com/OpenSourceAGI/GRAB-URL/tree/master/packages/quantum-sphere-loading-animation#readme",
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",


### PR DESCRIPTION
Unblocks npm publishing. Follow-up to #52, but an independent bug.

## The failure

Every `npm publish --provenance` from CI fails with a 422. From [the publish run on `master` right after #52 merged](https://github.com/OpenSourceAGI/GRAB-URL/actions/runs/34612008302):

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/archiver-web
  Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "git+https://github.com/vtempest/GRAB-URL.git",
  expected to match "https://github.com/OpenSourceAGI/GRAB-URL" from provenance
```

Both packages that attempted to publish — `archiver-web@1.1.3` and `quantum-sphere-loading-icon@1.0.4` — built fine, packed fine, signed their provenance statement, and were then rejected by the registry at the final PUT.

## The cause

The repository now lives at `OpenSourceAGI/GRAB-URL`. The GitHub API reports it with no `parent` and no `source`, so it is the canonical repo, not a fork. But `repository`, `bugs` and `homepage` in five `package.json` files still named `vtempest`. The provenance attestation is generated from the repository the workflow actually runs in, so npm rejects the mismatch and nothing can publish.

## The fix

Repoints those three fields in the root package and in the four packages that publish:

| Package | |
| --- | --- |
| `grab-url` (root) | `repository.url` |
| `api2client` | `repository.url`, `bugs.url`, `homepage` |
| `archiver-web` | `repository.url`, `bugs.url`, `homepage` |
| `loading-animations` | `repository.url`, `bugs.url`, `homepage` |
| `quantum-sphere-loading-icon` | `repository.url`, `bugs.url`, `homepage` |

`packages/native-app-wrapper` already carried the `OpenSourceAGI` URLs — this brings the rest in line with it.

`author: "vtempest"` is deliberately left alone in all five: that is a person, not a repository.

## Verification

- Every `package.json` in the repo still parses.
- `npm pack --dry-run` unchanged: root **125** dist entries, `archiver-web` **35**, `quantum-sphere` **12** — this PR touches only metadata.

## Two pre-existing issues this run also surfaced

Neither is touched here; noting them so they are not lost.

1. **`archiver-web`'s `bin` entries point at files the build never produces.** The publish log warns four times: `No bin file found at dist/bin-extract.js` / `dist/bin-compress.js`. The build emits `bin-extract.es.js` and `bin-extract.cjs.js`, so `extract` and `compress` have been broken for as long as those entries have existed. npm also reports `"bin[extract]" script name was cleaned`.
2. **`Tests` is still red on `master`** — the yt-dlp design conflict in `test/page-archive.test.ts` described in #52. Unrelated to publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3wkKQsRoi6k3DTvBRQhHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3wkKQsRoi6k3DTvBRQhHd)_