### PR TITLE
📝 docs(readme): add an "Open in StackBlitz" badge to the README badge rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   <a href="https://npmjs.org/package/grab-url"><img alt="NPM Version" src="https://img.shields.io/npm/v/grab-url" /></a>
   <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/vtempest/GRAB-URL" /></a>
   <a href="https://codespaces.new/vtempest/GRAB-URL"><img src="https://github.com/codespaces/badge.svg" width="150" height="20" alt="GitHub Codespaces" /></a>
+  <a href="https://stackblitz.com/github/OpenSourceAGI/GRAB-URL/tree/master/examples/basic-request"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
 <br />
    <img  src="https://i.imgur.com/xzFQmrD.jpeg" />
 </p>

--- a/grab-help-docs/content/docs/index.mdx
+++ b/grab-help-docs/content/docs/index.mdx
@@ -27,6 +27,7 @@ displayed_sidebar: lib
     <a href="https://npmjs.org/package/grab-url"><img alt="NPM Version" src="https://img.shields.io/npm/v/grab-url" /></a>
     <a href="https://github.com/vtempest/GRAB-URL/discussions"><img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/vtempest/GRAB-URL" /></a>
     <a href="https://codespaces.new/vtempest/GRAB-URL"><img src="https://github.com/codespaces/badge.svg" width="150" height="20"/></a>
+    <a href="https://stackblitz.com/github/OpenSourceAGI/GRAB-URL/tree/master/examples/basic-request"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
 </p>
 <h3 align="center">
   <a href="https://grab.js.org"> 📑 Docs (grab.js.org)</a>

--- a/packages/quantum-sphere-loading-animation/README.md
+++ b/packages/quantum-sphere-loading-animation/README.md
@@ -17,6 +17,7 @@
   <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI">
   <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome" /></a>
   <a href="https://codespaces.new/vtempest/GRAB-URL"><img src="https://github.com/codespaces/badge.svg" width="150" height="20" alt="GitHub Codespaces" /></a>
+  <a href="https://stackblitz.com/github/OpenSourceAGI/GRAB-URL/tree/master/packages/quantum-sphere-loading-animation"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
 </p>
 
 # Quantum Sphere Loading


### PR DESCRIPTION
Adds an **Open in StackBlitz** badge to every badge row in this repo.

StackBlitz installs from the manifest at the path it is handed, so each badge points at a directory that boots on its own rather than at the repo root:

| Badge row | Opens |
| --- | --- |
| `README.md` | `examples/basic-request` — the self-contained example the docs already open with `<StackBlitzExample>` |
| `grab-help-docs/content/docs/index.mdx` (the same row, on the docs home) | `examples/basic-request` |
| `packages/quantum-sphere-loading-animation/README.md` | that package |

The badge sits next to the existing "Open in GitHub Codespaces" badge in each row, using StackBlitz's own `open_in_stackblitz.svg`.

No code, build or docs-pipeline changes — Markdown/MDX only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kkb27RSQgLWvRWv1vcdJef

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kkb27RSQgLWvRWv1vcdJef)_