### PR TITLE
🐛 fix(test): drop the ytdlp tests left behind by the --page merge

### DIFF
--- a/test/page-archive.test.ts
+++ b/test/page-archive.test.ts
@@ -3,7 +3,6 @@
  * @description Unit tests for `grab-url --page`, the page archiver:
  *   - page/folder-name.ts          (title -> safe directory name)
  *   - page/archive-html.ts         (citation + document builders)
- *   - transfer/ytdlp-transfer.ts   (yt-dlp arg building + progress parsing)
  *   - page/archive-page.ts         (orchestration, against a stubbed extractor)
  */
 
@@ -27,15 +26,6 @@ import {
     buildContentDocument,
     buildTranscriptDocument,
 } from '../packages/grab-url-cli/src/page/archive-html.js';
-
-import {
-    parseYtDlpSize,
-    parseYtDlpEta,
-    parseYtDlpProgress,
-    buildYtDlpArgs,
-    describeYtDlpExit,
-    ytDlpInstallHint,
-} from '../packages/grab-url-cli/src/transfer/ytdlp-transfer.js';
 
 // ─── folder-name ──────────────────────────────────────────────────────────────
 
@@ -214,101 +204,6 @@ describe('archive-html — document builders', () => {
         expect(doc).toContain('<title>Transcript - A Video</title>');
         expect(doc).toContain('<p>hello there</p>');
         expect(doc).toContain('https://youtu.be/x');
-    });
-});
-
-// ─── ytdlp-transfer ───────────────────────────────────────────────────────────
-
-describe('ytdlp-transfer — parseYtDlpSize()', () => {
-    it('parses binary units', () => {
-        expect(parseYtDlpSize('1.00KiB')).toBe(1024);
-        expect(parseYtDlpSize('2MiB')).toBe(2 * 1024 ** 2);
-        expect(parseYtDlpSize('1.5GiB')).toBe(Math.round(1.5 * 1024 ** 3));
-    });
-
-    it('ignores the "~" yt-dlp puts on an estimated total', () => {
-        expect(parseYtDlpSize('~12.00MiB')).toBe(12 * 1024 ** 2);
-    });
-
-    it('returns 0 for junk or missing tokens', () => {
-        expect(parseYtDlpSize('Unknown')).toBe(0);
-        expect(parseYtDlpSize(undefined)).toBe(0);
-        expect(parseYtDlpSize('')).toBe(0);
-    });
-});
-
-describe('ytdlp-transfer — parseYtDlpEta()', () => {
-    it('parses mm:ss', () => expect(parseYtDlpEta('00:42')).toBe(42));
-    it('parses hh:mm:ss', () => expect(parseYtDlpEta('01:02:03')).toBe(3723));
-    it('returns 0 for "Unknown"', () => expect(parseYtDlpEta('Unknown')).toBe(0));
-    it('returns 0 for a missing token', () => expect(parseYtDlpEta(undefined)).toBe(0));
-});
-
-describe('ytdlp-transfer — parseYtDlpProgress()', () => {
-    it('parses a standard progress line', () => {
-        const p = parseYtDlpProgress(
-            '[download]  23.4% of ~12.00MiB at    1.00MiB/s ETA 00:42',
-        );
-        expect(p).not.toBeNull();
-        expect(p!.percent).toBeCloseTo(23.4);
-        expect(p!.total).toBe(12 * 1024 ** 2);
-        expect(p!.speedBps).toBe(1024 ** 2);
-        expect(p!.etaSeconds).toBe(42);
-        expect(p!.downloaded).toBe(Math.round(12 * 1024 ** 2 * 0.234));
-    });
-
-    it('parses a completed line with an unknown speed', () => {
-        const p = parseYtDlpProgress('[download] 100% of 5.00MiB in 00:03');
-        expect(p!.percent).toBe(100);
-        expect(p!.total).toBe(5 * 1024 ** 2);
-        expect(p!.speedBps).toBe(0);
-    });
-
-    it('returns null for non-progress output', () => {
-        expect(parseYtDlpProgress('[youtube] abc: Downloading webpage')).toBeNull();
-        expect(parseYtDlpProgress('[download] Destination: video.mp4')).toBeNull();
-        expect(parseYtDlpProgress('')).toBeNull();
-    });
-});
-
-describe('ytdlp-transfer — buildYtDlpArgs()', () => {
-    it('never expands a playlist and always writes into --paths', () => {
-        const args = buildYtDlpArgs('https://youtu.be/x', { dir: '/tmp/out' });
-        expect(args).toContain('--no-playlist');
-        expect(args[args.indexOf('--paths') + 1]).toBe('/tmp/out');
-        expect(args[args.length - 1]).toBe('https://youtu.be/x');
-    });
-
-    it('uses the supplied base name but leaves the extension to yt-dlp', () => {
-        const args = buildYtDlpArgs('https://youtu.be/x', { filename: 'My Video' });
-        expect(args[args.indexOf('--output') + 1]).toBe('My Video.%(ext)s');
-    });
-
-    it('passes a format selector through', () => {
-        const args = buildYtDlpArgs('https://youtu.be/x', { format: 'bestaudio' });
-        expect(args[args.indexOf('--format') + 1]).toBe('bestaudio');
-    });
-
-    it('omits --format when none was given', () => {
-        expect(buildYtDlpArgs('https://youtu.be/x')).not.toContain('--format');
-    });
-
-    it('appends extra args before the URL', () => {
-        const args = buildYtDlpArgs('https://youtu.be/x', { extraArgs: ['--limit-rate', '1M'] });
-        expect(args.slice(-3)).toEqual(['--limit-rate', '1M', 'https://youtu.be/x']);
-    });
-});
-
-describe('ytdlp-transfer — misc', () => {
-    it('describes known exit codes', () => {
-        expect(describeYtDlpExit(0)).toBe('completed');
-        expect(describeYtDlpExit(1)).toBe('download failed');
-        expect(describeYtDlpExit(null)).toBe('terminated by signal');
-        expect(describeYtDlpExit(77)).toContain('77');
-    });
-
-    it('always offers an install hint', () => {
-        expect(ytDlpInstallHint().length).toBeGreaterThan(0);
     });
 });
 

--- a/test/ytdlp.test.ts
+++ b/test/ytdlp.test.ts
@@ -296,7 +296,10 @@ describe('yt-dlp — isYtDlpNoise()', () => {
 describe('yt-dlp — describeYtDlpExit()', () => {
     it('names the common exit codes', () => {
         expect(describeYtDlpExit(0)).toBe('completed');
+        expect(describeYtDlpExit(1)).toContain('download failed');
         expect(describeYtDlpExit(2)).toBe('bad command-line option');
+        expect(describeYtDlpExit(100)).toContain('Python');
+        expect(describeYtDlpExit(101)).toContain('stopped early');
         expect(describeYtDlpExit(null)).toBe('terminated by signal');
     });
     it('falls back to the raw code', () => {


### PR DESCRIPTION
## What's broken

The `Tests` workflow has been red on `master` since the `--page` merge — [run #184](https://github.com/OpenSourceAGI/GRAB-URL/actions/runs/34661685054) and every run since. 11 failures, all in `test/page-archive.test.ts`.

## Why

`test/page-archive.test.ts` and `test/ytdlp.test.ts` arrived on two different branches, and **each branch added its own `packages/grab-url-cli/src/transfer/ytdlp-transfer.ts`**:

- `98b613f` ✨ feat(cli): route media-site URLs through yt-dlp → brought `ytdlp-transfer.ts` + `test/ytdlp.test.ts`
- `fc2365d` ✨ feat(cli): archive a page into a folder with --page → brought a *different* `ytdlp-transfer.ts` + `test/page-archive.test.ts`

The merge (`dc2179d`) resolved the source file in favour of the sentinel-`@GRAB@`-progress-template implementation, but kept **both** test files. So the `ytdlp-transfer` block inside `page-archive.test.ts` is still testing the API of the side that lost the merge:

| The stale test expects | The surviving implementation |
| --- | --- |
| `parseYtDlpSize()`, `parseYtDlpEta()` | don't exist — the progress template emits raw bytes/seconds, parsed by a private `parseField()` |
| `parseYtDlpProgress('[download] 23.4% of ~12.00MiB at 1.00MiB/s ETA 00:42')` | parses only `@GRAB@`-sentinel lines; returns `null` for yt-dlp's human readout |
| `buildYtDlpArgs(url, { filename: 'My Video' })` | the option is `output`, used verbatim as the template |
| `describeYtDlpExit(1) === 'download failed'` | `'download failed — the media may be private, region-locked or removed'` |

Seven of the eleven failures are literally `No "parseYtDlpSize" export is defined on the mock` — the export has never existed on the merged module.

## The fix

Removed the stale block rather than rewriting it, because **`test/ytdlp.test.ts` already covers the surviving implementation in more depth** — `buildYtDlpArgs` (9 cases incl. the output template, `--paths`, format, audio extraction, cookies, extra args), `parseYtDlpProgress` (7 cases incl. estimates, HLS fragment counters, `NA`/`None`, a mid-line sentinel, truncated lines), `describeYtDlpExit`, and `ytDlpInstallHint`. Keeping a second, contradictory copy buys nothing.

The two assertions the stale block held that the survivor did not — exit codes `1`, `100` and `101` — move into `describeYtDlpExit()` in `test/ytdlp.test.ts`, so no assertion is lost.

The `vi.mock` of `ytdlp-transfer.js` stays: the `archive-page` orchestration tests in the same file still need it.

## Verification

`npm run test:coverage`, exactly what CI runs:

```
Before: Test Files  1 failed | 10 passed (11)
        Tests      11 failed | 343 passed (354)   → exit 1

After:  Test Files  11 passed (11)
        Tests      337 passed (337)               → exit 0
```

Coverage is unmoved (42.56% → 42.53% statements) — the deleted tests exercised code paths `ytdlp.test.ts` already reaches. No source file is touched, so nothing bundled changes and no rebuild is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSN1eSaRTWxr2BmPc3xQ4i

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSN1eSaRTWxr2BmPc3xQ4i)_