### PR TITLE
🔖 chore(release): 1.6.23 — ship grab's onRawResponse hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ***
 
+## 1.6.23 — `onRawResponse`, released
+
+`grab()` gained an **`onRawResponse` hook** — it hands the caller the raw
+`Response` before grab parses or throws on it — plus a **`grab.supports`**
+feature-flag object so integrations can detect the hook instead of guessing
+from a version number. Both landed with `api2client` (PR #14) but were never
+released, so every published `api2client` fell back to its no-`onRawResponse`
+path: an OpenAPI SDK on it lost the HTTP status and the parsed error body on
+any non-2xx response. This release is that fix — the code is unchanged, it
+simply ships.
+
+***
+
 ## September 2026 — Docs overhaul and runnable examples
 
 The current month has been a concentrated push on the documentation site. **README and docs-site badges** were brought to parity with debate-ai.com, with **npm downloads**, **bundle size** and **grab.js.org** badges added (PRs #15, #16, #17). An **OpenAPI SDKs overview page** and matching homepage section were published (PR #18), followed by a **Hey API setup guide**.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "grab-url",
   "description": "Generate Request to API from Browser",
   "type": "module",
-  "version": "1.6.22",
+  "version": "1.6.23",
   "packageManager": "npm@11.19.1",
   "author": "vtempest",
   "license": "rights.institute/prosper",


### PR DESCRIPTION
A version bump, no code change.

## The problem

`onRawResponse` — the hook that hands a caller the raw `Response` before grab parses or throws on it — and the `grab.supports` feature-flag object both landed with `api2client` (#14). The version was never bumped, so **neither has ever been on npm**: the newest published `grab-url` is 1.6.22, without either.

```js
// packages/grab-api/src/index.ts:30 — in source since #14, never released
grab.supports = { onRawResponse: true };
```

That leaves every published `api2client` permanently on its fallback path. api2client probes `grab.supports.onRawResponse` before asking grab for the raw Response:

```ts
// packages/api2client/src/client.ts:79
const supportsRawResponse = (grab: any): boolean =>
  (grab?.supports ?? (defaultGrab as any)?.supports)?.onRawResponse === true;
```

With the probe false there is no `Response` to return, so an OpenAPI SDK built on api2client loses:

- **the HTTP status** — `result.response` is `undefined`, so callers cannot tell a 401 from a 500
- **the parsed error body** — `result.error` becomes grab's own `"HTTP error: <status>"` string instead of the handler's JSON
- `cacheForTime`, `retryAttempts`, `parseDOM` and `unescapeHTML`, which are gated behind the same probe

## Why now

`qwksearch-api-client` is moving onto api2client in OpenSourceAGI/qwksearch-research-agent#478 and needs this release to keep the error shape its consumers read — `research-agent-ui`'s 401 stale-session fallback branches on `response?.status`. That PR ships with its error-shape test skipping itself on a grab without the hook; the assertions start running once 1.6.23 is published.

`api2client@1.0.1` already depends on `grab-url: ^1.6.22`, so a 1.6.23 publish reaches it with no further change.

## Change

`package.json` 1.6.22 → 1.6.23, plus a CHANGELOG entry. The hook is already implemented in `packages/grab-api/src`; this is the bump that publishes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014M96Bt2EuEo6jV9YypGE15

---
_Generated by [Claude Code](https://claude.ai/code/session_014M96Bt2EuEo6jV9YypGE15)_